### PR TITLE
disable non working overscan cropping

### DIFF
--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -41,7 +41,7 @@
 static EmulateSpecStruct* espec = NULL;
 static bool PAL;
 static bool CorrectAspect;
-static bool ShowHOverscan;
+static bool ShowHOverscan = true;
 static bool DoHBlend;
 static int LineVisFirst, LineVisLast;
 static uint32 OutLineCounter;


### PR DESCRIPTION
In medanfen stand-alone it's enabled/disabled in vdp2_render.cpp:
void VDP2REND_SetGetVideoParams(MDFNGI* gi, const bool caspect, const int sls, const int sle, const bool show_h_overscan, const bool dohblend)

As it's not working properly in retroarch when it's false, let's just put it to true here directly.

Recentre the picture that was off to the right.