### PR TITLE
WinRT compilation and more

### DIFF
--- a/libretro-common/string/stdstring.c
+++ b/libretro-common/string/stdstring.c
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <ctype.h>
 
+#include <compat/msvc.h>
 #include <string/stdstring.h>
 
 bool string_is_empty(const char *data)

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -75,7 +75,7 @@ char retro_cd_base_name[4096];
 #endif
 
 extern MDFNGI EmulatedSS;
-MDFNGI *MDFNGameInfo = &EmulatedSS;
+MDFNGI *MDFNGameInfo = NULL;
 
 #include "../MemoryStream.h"
 
@@ -2519,6 +2519,11 @@ static MDFNGI *MDFNI_LoadCD(const char *devicename)
 
    log_cb(RETRO_LOG_DEBUG, "Done calculating layout MD5.\n");
    // TODO: include module name in hash
+   if (MDFNGameInfo == NULL)
+   {
+      MDFNGameInfo = &EmulatedSS;
+   }
+
    memcpy(MDFNGameInfo->MD5, LayoutMD5, 16);
 
    if(!(LoadCD(&CDInterfaces)))

--- a/mednafen/cdrom/dvdisaster.h
+++ b/mednafen/cdrom/dvdisaster.h
@@ -46,7 +46,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 /***
  *** dvdisaster.c

--- a/mednafen/hash/sha256.cpp
+++ b/mednafen/hash/sha256.cpp
@@ -109,7 +109,7 @@ static INLINE void block(std::array<uint32, 8> &h, void* blk_data)
 sha256_digest sha256(const void* data, const uint64 len)
 {
  sha256_digest ret;
- alignas(16) std::array<uint32, 8> h({{ 0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19 }});
+ alignas(16) std::array<uint32, 8> h = { 0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19 };
  uint8* p = (uint8*)data;
  uint64 dc = len;
 

--- a/mednafen/hw_cpu/m68k/m68k.cpp
+++ b/mednafen/hw_cpu/m68k/m68k.cpp
@@ -2282,70 +2282,73 @@ void M68K::Reset(bool powering_up)
 //
 uint32 M68K::GetRegister(unsigned which, char* special, const uint32 special_len)
 {
- switch(which)
- {
-  default:
-	return 0xDEADBEEF;
-
-  case GSREG_D0 ... GSREG_D7:
-	return D[which - GSREG_D0];
-
-  case GSREG_A0 ... GSREG_A7:
-	return A[which - GSREG_A0];
-
-  case GSREG_PC:
-	return PC;
-
-  case GSREG_SR:
-	return GetSR();
-
-  case GSREG_SSP:
-	if(GetSVisor())
-	 return A[7];
-	else
-	 return SP_Inactive;
-
-  case GSREG_USP:
-	if(!GetSVisor())
-	 return A[7];
-	else
-	 return SP_Inactive;
- }
+  if (which >= GSREG_D0 && which <= GSREG_D7)
+  {
+    return D[which - GSREG_D0];
+  }
+  else if (which >= GSREG_A0 && which <= GSREG_A7)
+  {
+    return A[which - GSREG_A0];
+  }
+  else if (which == GSREG_PC)
+  {
+    return PC;
+  }
+  else if (which == GSREG_SR)
+  {
+    return GetSR();
+  }
+  else if (which == GSREG_SSP)
+  {
+    if (GetSVisor())
+      return A[7];
+    else
+      return SP_Inactive;
+  }
+  else if (which == GSREG_USP)
+  {
+    if (!GetSVisor())
+      return A[7];
+    else
+      return SP_Inactive;
+  }
+  else
+  {
+    return 0xDEADBEEF;
+  }
 }
 
 void M68K::SetRegister(unsigned which, uint32 value)
 {
- switch(which)
- {
-  case GSREG_D0 ... GSREG_D7:
-	D[which - GSREG_D0] = value;
-	break;
-
-  case GSREG_A0 ... GSREG_A7:
-	A[which - GSREG_A0] = value;
-	break;
-
-  case GSREG_PC:
-	PC = value;
-	break;
-
-  case GSREG_SR:
-	SetSR(value);
-	break;
-
-  case GSREG_SSP:
-	if(GetSVisor())
-	 A[7] = value;
-	else
-	 SP_Inactive = value;
-	break;
-
-  case GSREG_USP:
-	if(!GetSVisor())
-	 A[7] = value;
-	else
-	 SP_Inactive = value;
-	break;
- }
+  if (which >= GSREG_D0 && which <= GSREG_D7)
+  {
+    D[which - GSREG_D0] = value;
+  }
+  else if (which >= GSREG_A0 && which <= GSREG_A7)
+  {
+    A[which - GSREG_A0] = value;
+  }
+  else if (which == GSREG_PC)
+  {
+    PC = value;
+  }
+  else if (which == GSREG_SR)
+  {
+    SetSR(value);
+  }
+  else if (which == GSREG_SSP)
+  {
+    if (GetSVisor())
+      A[7] = value;
+    else
+      SP_Inactive = value;
+  }
+  else if (which == GSREG_USP)
+  {
+    if (!GetSVisor())
+      A[7] = value;
+    else
+      SP_Inactive = value;
+  }
 }
 

--- a/mednafen/mednafen-endian.h
+++ b/mednafen/mednafen-endian.h
@@ -13,7 +13,11 @@
 #define MDFN_ASSUME_ALIGNED(p, align) (p)
 #endif
 #else
+#ifndef _MSC_VER
 #define MDFN_ASSUME_ALIGNED(p, align) ((decltype(p))__builtin_assume_aligned((p), (align)))
+#else
+#define MDFN_ASSUME_ALIGNED(p, align) p
+#endif
 #endif
 
 #ifdef MSB_FIRST

--- a/mednafen/ss/cdb.cpp
+++ b/mednafen/ss/cdb.cpp
@@ -927,6 +927,8 @@ static void ClearPendingSec(void);
 
 static bool FLS_Run(void)
 {
+ static const char stdid[5] = { 'C', 'D', '0', '0', '1' };
+
  bool ret = false;
  //printf("%d, %d\n", Partitions[FLS.pnum].Count, FreeBufferCount);
 
@@ -952,7 +954,6 @@ static bool FLS_Run(void)
 
    for(;;)
    {
-    static const char stdid[5] = { 'C', 'D', '0', '0', '1' };
     FLS_WAIT_GRAB_BUF;
 
     if(memcmp(FLS.pbuf + 1, stdid, 5) || FLS.pbuf[0] == 0xFF)

--- a/mednafen/ss/cdb.cpp
+++ b/mednafen/ss/cdb.cpp
@@ -797,7 +797,13 @@ static struct FileInfoS
  uint8 gap_size;
  uint8 fnum;
  uint8 attr;
-} __attribute__((__packed__)) FileInfo[256];
+}
+#ifndef _MSC_VER
+__attribute__((__packed__)) FileInfo[256];
+#else
+FileInfo[256];
+#endif
+
 static bool FileInfoValid;
 
 enum

--- a/mednafen/ss/ss.h
+++ b/mednafen/ss/ss.h
@@ -64,12 +64,17 @@
 
  static INLINE void SS_DBG_Dummy(const char* format, ...) { }
 
+#ifndef _MSC_VER
 #ifdef HAVE_DEBUG
 #define SS_DBG(which, format, ...) ((MDFN_UNLIKELY(ss_dbg_mask & (which))) ? (void)trio_printf(format, ## __VA_ARGS__) : SS_DBG_Dummy(format, ## __VA_ARGS__))
 #else
 #define SS_DBG(which, format, ...) SS_DBG_Dummy(format, ## __VA_ARGS__)
 #endif
- #define SS_DBGTI(which, format, ...) SS_DBG(which, format " @Line=0x%03x, HPos=0x%03x\n", ## __VA_ARGS__, VDP2::PeekLine(), VDP2::PeekHPos())
+#define SS_DBGTI(which, format, ...) SS_DBG(which, format " @Line=0x%03x, HPos=0x%03x\n", ## __VA_ARGS__, VDP2::PeekLine(), VDP2::PeekHPos())
+#else
+#define SS_DBG(which, format, ...) SS_DBG_Dummy(format)
+#define SS_DBGTI SS_DBG
+#endif
 
  template<unsigned which>
  static void SS_DBG_Wrap(const char* format, ...) noexcept

--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -457,21 +457,23 @@ struct RotVars
  TileFetcher<true> tf;
 };
 
+typedef uint64 nbgarr[4][8 + 704 + 8];
+
 static struct
 {
  uint64 spr[704];
  uint64 rbg0[704];
  union
  {
-  uint64 nbg[4][8 + 704 + 8];
+  nbgarr nbg;
   struct
   {
-   uint8 dummy[sizeof(nbg) / 2];
+   uint8 dummy[sizeof(nbgarr) / 2];
    uint16 vcscr[2][88 + 1 + 1];	// + 1 for fine x scroll != 0, + 1 for pointer shenanigans in FetchVCScroll
   };
   struct
   {
-   uint8 rotdummy[sizeof(nbg) / 4];
+   uint8 rotdummy[sizeof(nbgarr) / 4];
    uint8 rotabsel[352];	// Also used as a scratch buffer in T_DrawRBG() to handle mosaic-related junk.
    RotVars rotv[2];
    uint32 rotcoeff[352];


### PR DESCRIPTION
- Modified core to compile under WinRT
- Fixed a bug that made core unusable after calling `retro_unload()`, same as BeetlePSX
