### PR TITLE
Store 3D Pad mode switch in save states

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -445,11 +445,11 @@ int input_StateAction( StateMem* sm, const unsigned load, const bool data_only )
 
 	SFORMAT StateRegs[] =
 	{
-		SFARRAY16N( input_mode, sizeof( input_mode ), "mode" ),
+		SFARRAY16N( input_mode, MAX_CONTROLLERS, "mode" ),
 		SFEND
 	};
 
-	success = MDFNSS_StateAction( sm, load, data_only, StateRegs, "LRINPUT" );
+	success = MDFNSS_StateAction( sm, load, data_only, StateRegs, "LIBRETRO-INPUT" );
 
 	// ok?
 	return success;

--- a/input.cpp
+++ b/input.cpp
@@ -3,6 +3,7 @@
 #include "mednafen/mednafen-types.h"
 #include "mednafen/ss/ss.h"
 #include "mednafen/ss/smpc.h"
+#include "mednafen/state.h"
 #include <math.h>
 #include <stdio.h>
 
@@ -38,7 +39,7 @@ static uint32_t input_type[ MAX_CONTROLLERS ] = {0};
 #define INPUT_MODE_3D_PAD_DEFAULT		INPUT_MODE_3D_PAD_ANALOG
 
 // Mode switch for 3D Control Pad (per player)
-static uint32_t input_mode[ MAX_CONTROLLERS ] = {0};
+static uint16_t input_mode[ MAX_CONTROLLERS ] = {0};
 
 
 
@@ -308,8 +309,8 @@ void input_update( retro_input_state_t input_state_cb )
 
 				{
 					// Handle MODE button as a switch
-					unsigned prev = ( input_mode[iplayer] & INPUT_MODE_3D_PAD_PREVIOUS_MASK );
-					unsigned held = input_state_cb( iplayer, RETRO_DEVICE_JOYPAD, 0, input_map_3d_pad_mode_switch )
+					uint16_t prev = ( input_mode[iplayer] & INPUT_MODE_3D_PAD_PREVIOUS_MASK );
+					uint16_t held = input_state_cb( iplayer, RETRO_DEVICE_JOYPAD, 0, input_map_3d_pad_mode_switch )
 						? INPUT_MODE_3D_PAD_PREVIOUS_MASK : 0;
 
 					// Rising edge trigger
@@ -437,6 +438,22 @@ void input_update( retro_input_state_t input_state_cb )
 	}; // for each player
 }
 
+// save state function for input
+int input_StateAction( StateMem* sm, const unsigned load, const bool data_only )
+{
+	int success;
+
+	SFORMAT StateRegs[] =
+	{
+		SFARRAY16N( input_mode, sizeof( input_mode ), "mode" ),
+		SFEND
+	};
+
+	success = MDFNSS_StateAction( sm, load, data_only, StateRegs, "LRINPUT" );
+
+	// ok?
+	return success;
+}
 
 //------------------------------------------------------------------------------
 // Libretro Interface

--- a/input.h
+++ b/input.h
@@ -1,6 +1,9 @@
 #ifndef __INPUT_H__
 #define __INPUT_H__
 
+#include "libretro.h"
+#include "mednafen/state.h"
+
 // These input routines tell libretro about Saturn peripherals
 // and map input from the abstract 'retropad' into Saturn land.
 
@@ -13,5 +16,8 @@ extern void input_set_env( retro_environment_t environ_cb );
 extern void input_set_deadzone_stick( int percent );
 
 extern void input_update( retro_input_state_t input_state_cb );
+
+// save state function for input
+extern int input_StateAction( StateMem* sm, const unsigned load, const bool data_only );
 
 #endif

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2012,10 +2012,9 @@ MDFN_COLD int LibRetro_StateAction( StateMem* sm, const unsigned load, const boo
 		return 0;
 	}
 
-	success = input_StateAction( sm, load, data_only );
+	input_StateAction( sm, load, data_only );
 	if ( success == 0 ) {
-		log_cb( RETRO_LOG_ERROR, "Input save-state failed.\n" );
-		return 0;
+		log_cb( RETRO_LOG_WARN, "Input state failed.\n" );
 	}
 
 	if ( load )

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2012,7 +2012,7 @@ MDFN_COLD int LibRetro_StateAction( StateMem* sm, const unsigned load, const boo
 		return 0;
 	}
 
-	input_StateAction( sm, load, data_only );
+	success = input_StateAction( sm, load, data_only );
 	if ( success == 0 ) {
 		log_cb( RETRO_LOG_WARN, "Input state failed.\n" );
 	}

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2012,6 +2012,12 @@ MDFN_COLD int LibRetro_StateAction( StateMem* sm, const unsigned load, const boo
 		return 0;
 	}
 
+	success = input_StateAction( sm, load, data_only );
+	if ( success == 0 ) {
+		log_cb( RETRO_LOG_ERROR, "Input save-state failed.\n" );
+		return 0;
+	}
+
 	if ( load )
 	{
 		BackupRAM_Dirty = true;


### PR DESCRIPTION
Adds the input front-end 'mode' to the save state file. The input mode stores the 3D Pad analog/digital mode switch setting, so when saving a state that setting is now preserved.

Compatible with existing save state files (will include the new data on next save.)