### PR TITLE
Extra mouse buttons

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -451,7 +451,9 @@ void input_update( retro_input_state_t input_state_cb )
 					p_input->u8[0x8] |= ( 1 << 2 ); // C
 				}
 
-				if ( input_state_cb( iplayer, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START ) ) {
+				if ( input_state_cb( iplayer, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START ) ||
+					 input_state_cb( iplayer, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_BUTTON_4 ) ||
+					 input_state_cb( iplayer, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_BUTTON_5 ) ) {
 					p_input->u8[0x8] |= ( 1 << 3 ); // Start
 				}
 

--- a/libretro.h
+++ b/libretro.h
@@ -208,6 +208,8 @@ extern "C" {
 #define RETRO_DEVICE_ID_MOUSE_MIDDLE           6
 #define RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP    7
 #define RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN  8
+#define RETRO_DEVICE_ID_MOUSE_BUTTON_4         9
+#define RETRO_DEVICE_ID_MOUSE_BUTTON_5         10
 
 /* Id values for LIGHTGUN types. */
 #define RETRO_DEVICE_ID_LIGHTGUN_X        0


### PR DESCRIPTION
Added support for RETRO_DEVICE_ID_MOUSE_BUTTON_4 and RETRO_DEVICE_ID_MOUSE_BUTTON_5

Mapped these controls to the Saturn mouse 'start' button.

Note these new constants are still pending approval by libretro-common / RetroArch as of this post.