### PR TITLE
Analog buttons

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -18,6 +18,7 @@ static retro_environment_t environ_cb; // cached during input_set_env
 static unsigned players = MAX_CONTROLLERS;
 
 static int astick_deadzone = 0;
+static int trigger_deadzone = 0;
 
 typedef union
 {
@@ -212,7 +213,14 @@ void input_init()
 
 void input_set_deadzone_stick( int percent )
 {
-	astick_deadzone = (int)( percent * 0.01f * 0x8000);
+	if ( percent >= 0 && percent <= 100 )
+		astick_deadzone = (int)( percent * 0.01f * 0x8000);
+}
+
+void input_set_deadzone_trigger( int percent )
+{
+	if ( percent >= 0 && percent <= 100 )
+		trigger_deadzone = (int)( percent * 0.01f * 0x8000);
 }
 
 void input_update( retro_input_state_t input_state_cb )

--- a/input.h
+++ b/input.h
@@ -14,6 +14,7 @@ extern void input_init();
 extern void input_set_env( retro_environment_t environ_cb );
 
 extern void input_set_deadzone_stick( int percent );
+extern void input_set_deadzone_trigger( int percent );
 
 extern void input_update( retro_input_state_t input_state_cb );
 

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2626,6 +2626,12 @@ static void check_variables(bool startup)
 
 	if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value )
 		input_set_deadzone_stick( atoi( var.value ) );
+
+	var.key = "beetle_saturn_trigger_deadzone";
+	var.value = NULL;
+
+	if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value )
+		input_set_deadzone_trigger( atoi( var.value ) );
 }
 
 #ifdef NEED_CD
@@ -3070,6 +3076,7 @@ void retro_set_environment( retro_environment_t cb )
       { "beetle_saturn_initial_scanline_pal", "Initial scanline PAL; 16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60|0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15" },
       { "beetle_saturn_last_scanline_pal", "Last scanline PAL; 271|272|273|274|275|276|277|278|279|280|281|282|283|284|285|286|287|230|231|232|233|234|235|236|237|238|239|240|241|242|243|244|245|246|247|248|249|250|251|252|253|254|255|256|257|258|259|260|261|262|263|264|265|266|267|268|269|270" },
       { "beetle_saturn_analog_stick_deadzone", "Analog Deadzone (percent); 15|20|25|30|0|5|10"},
+      { "beetle_saturn_trigger_deadzone", "Trigger Deadzone (percent); 15|20|25|30|0|5|10"},
       { NULL, NULL },
    };
 

--- a/libretro.h
+++ b/libretro.h
@@ -131,11 +131,12 @@ extern "C" {
 #define RETRO_DEVICE_LIGHTGUN     4
 
 /* The ANALOG device is an extension to JOYPAD (RetroPad).
- * Similar to DualShock it adds two analog sticks.
- * This is treated as a separate device type as it returns values in the 
- * full analog range of [-0x8000, 0x7fff]. Positive X axis is right.
- * Positive Y axis is down.
- * Only use ANALOG type when polling for analog values of the axes.
+ * Similar to DualShock2 it adds two analog sticks and all buttons can
+ * be analog. This is treated as a separate device type as it returns
+ * axis values in the full analog range of [-0x8000, 0x7fff].
+ * Positive X axis is right. Positive Y axis is down.
+ * Buttons are returned in the range [0, 0x7fff].
+ * Only use ANALOG type when polling for analog values.
  */
 #define RETRO_DEVICE_ANALOG       5
 
@@ -174,7 +175,8 @@ extern "C" {
 /* Buttons for the RetroPad (JOYPAD).
  * The placement of these is equivalent to placements on the 
  * Super Nintendo controller.
- * L2/R2/L3/R3 buttons correspond to the PS1 DualShock. */
+ * L2/R2/L3/R3 buttons correspond to the PS1 DualShock.
+ * Also used as id values for RETRO_DEVICE_INDEX_ANALOG_BUTTON */
 #define RETRO_DEVICE_ID_JOYPAD_B        0
 #define RETRO_DEVICE_ID_JOYPAD_Y        1
 #define RETRO_DEVICE_ID_JOYPAD_SELECT   2
@@ -193,10 +195,11 @@ extern "C" {
 #define RETRO_DEVICE_ID_JOYPAD_R3      15
 
 /* Index / Id values for ANALOG device. */
-#define RETRO_DEVICE_INDEX_ANALOG_LEFT   0
-#define RETRO_DEVICE_INDEX_ANALOG_RIGHT  1
-#define RETRO_DEVICE_ID_ANALOG_X         0
-#define RETRO_DEVICE_ID_ANALOG_Y         1
+#define RETRO_DEVICE_INDEX_ANALOG_LEFT       0
+#define RETRO_DEVICE_INDEX_ANALOG_RIGHT      1
+#define RETRO_DEVICE_INDEX_ANALOG_BUTTON     2
+#define RETRO_DEVICE_ID_ANALOG_X             0
+#define RETRO_DEVICE_ID_ANALOG_Y             1
 
 /* Id values for MOUSE. */
 #define RETRO_DEVICE_ID_MOUSE_X                0


### PR DESCRIPTION
Using the newly submitted analog buttons feature, I've updated the 3D Control Pad to support analog triggers. To use them simply bind analog inputs (e.g. the triggers on a 360 pad) to the RetroPad L2 and R2 buttons. (I already had these inputs bound so ideally there is no user input required.)

You will need the latest version of RetroArch to use this feature, otherwise it will fall back to the old digital behaviour. Using this feature lets you strafe smoothly in Quake, etc.

Note this is pending approval from libretro-common and RetroArch. 