### PR TITLE
Virtua Gun / Stunner support

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -564,6 +564,9 @@ void input_update( retro_input_state_t input_state_cb )
 					p_input->u8[0x4] |= 0x1; // Trigger
 				}
 
+				if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TURBO ) ) {
+					p_input->u8[0x4] |= 0x4; // Offscreen Shot(Simulated)
+
 				// start button
 				if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START ) ||
 					 input_state_cb( iplayer, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START ) ||
@@ -576,14 +579,14 @@ void input_update( retro_input_state_t input_state_cb )
 				// -- Position
 
 				int gun_x_raw, gun_y_raw;
-				gun_x_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X ) + 0x8000;
-				gun_y_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y ) + 0x8000;
+				gun_x_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X ) + 0x7fff;
+				gun_y_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y ) + 0x7fff;
 
 				// .. scale into screen space:
 				// NOTE: this is complete hacky guesswork for this first pass, need to re-write.
 				int gun_x, gun_y;
-				gun_x = ( gun_x_raw * 22000 ) / 65536;
-				gun_y = ( gun_y_raw * 240 ) / 65536;
+				gun_x = ( gun_x_raw * 21472 ) / (0x7fff << 1);
+				gun_y = ( gun_y_raw * 240 ) / (0x7fff << 1);
 
 				p_input->gun_pos[ 0 ] = gun_x;
 				p_input->gun_pos[ 1 ] = gun_y;

--- a/input.cpp
+++ b/input.cpp
@@ -49,14 +49,16 @@ static uint32_t input_mode[ MAX_CONTROLLERS ] = {0};
 #define RETRO_DEVICE_SS_PAD			RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_JOYPAD, 0 )
 #define RETRO_DEVICE_SS_3D_PAD		RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_ANALOG, 0 )
 #define RETRO_DEVICE_SS_WHEEL		RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_ANALOG, 1 )
+#define RETRO_DEVICE_SS_GUN			RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_LIGHTGUN, 0 )
 
-enum { INPUT_DEVICE_TYPES_COUNT = 1 /*none*/ + 3 }; // <-- update me!
+enum { INPUT_DEVICE_TYPES_COUNT = 1 /*none*/ + 4 }; // <-- update me!
 
 static const struct retro_controller_description input_device_types[ INPUT_DEVICE_TYPES_COUNT ] =
 {
 	{ "Control Pad", RETRO_DEVICE_JOYPAD },
 	{ "3D Control Pad", RETRO_DEVICE_SS_3D_PAD },
 	{ "Arcade Racer", RETRO_DEVICE_SS_WHEEL },
+	{ "Virtua Gun", RETRO_DEVICE_SS_GUN },
 	{ NULL, 0 },
 };
 
@@ -132,6 +134,7 @@ static const unsigned input_map_wheel_shift_right =
 	RETRO_DEVICE_ID_JOYPAD_R2;
 
 
+
 //------------------------------------------------------------------------------
 // Global Functions
 //------------------------------------------------------------------------------
@@ -159,6 +162,8 @@ void input_init_env( retro_environment_t _environ_cb )
 		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Analog X" },
 		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Analog Y" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "(3D Pad) Mode Switch" },
+		{ 0, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER, "(Gun) Trigger" },
+		{ 0, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START, "(Gun) Start" },
 
 		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
 		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
@@ -176,6 +181,8 @@ void input_init_env( retro_environment_t _environ_cb )
 		{ 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Analog X" },
 		{ 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Analog Y" },
 		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "(3D Pad) Mode Switch" },
+		{ 1, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER, "(Gun) Trigger" },
+		{ 1, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START, "(Gun) Start" },
 
 		{ 0 },
 	};
@@ -430,6 +437,21 @@ void input_update( retro_input_state_t input_state_cb )
 
 			break;
 
+		case RETRO_DEVICE_SS_GUN:
+
+			{
+				//
+				// -- Gun buttons
+
+				p_input->u8[0x4] = 0;
+				if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER ) ) {
+					p_input->u8[0x4] = ( 1 << 0 ); // Trigger
+				}
+				if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START ) ) {
+					p_input->u8[0x4] = ( 1 << 1 ); // Start
+				}
+			}
+
 		}; // switch ( input_type[ iplayer ] )
 
 	}; // for each player
@@ -469,6 +491,11 @@ void retro_set_controller_port_device( unsigned in_port, unsigned device )
 		case RETRO_DEVICE_SS_WHEEL:
 			log_cb( RETRO_LOG_INFO, "Controller %u: Arcade Racer\n", (in_port+1) );
 			SMPC_SetInput( in_port, "wheel", (uint8*)&input_data[ in_port ] );
+			break;
+
+		case RETRO_DEVICE_SS_GUN:
+			log_cb( RETRO_LOG_INFO, "Controller %u: Virtua Gun\n", (in_port+1) );
+			SMPC_SetInput( in_port, "gun", (uint8*)&input_data[ in_port ] );
 			break;
 
 		default:

--- a/input.cpp
+++ b/input.cpp
@@ -36,7 +36,8 @@ static uint32_t input_type[ MAX_CONTROLLERS ] = {0};
 #define INPUT_MODE_3D_PAD_ANALOG		( 1 << 0 ) // Set means analog mode.
 #define INPUT_MODE_3D_PAD_PREVIOUS_MASK	( 1 << 1 ) // Edge trigger helper.
 
-#define INPUT_MODE_3D_PAD_DEFAULT		INPUT_MODE_3D_PAD_ANALOG
+#define INPUT_MODE_DEFAULT				0
+#define INPUT_MODE_DEFAULT_3D_PAD		INPUT_MODE_3D_PAD_ANALOG
 
 // Mode switch for 3D Control Pad (per player)
 static uint32_t input_mode[ MAX_CONTROLLERS ] = {0};
@@ -163,8 +164,6 @@ void input_init_env( retro_environment_t _environ_cb )
 		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Analog X" },
 		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Analog Y" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "(3D Pad) Mode Switch" },
-		{ 0, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER, "(Gun) Trigger" },
-		{ 0, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START, "(Gun) Start" },
 
 		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
 		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
@@ -182,8 +181,6 @@ void input_init_env( retro_environment_t _environ_cb )
 		{ 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Analog X" },
 		{ 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Analog Y" },
 		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "(3D Pad) Mode Switch" },
-		{ 1, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER, "(Gun) Trigger" },
-		{ 1, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START, "(Gun) Start" },
 
 		{ 0 },
 	};
@@ -209,7 +206,7 @@ void input_init()
 	for ( unsigned i = 0; i < MAX_CONTROLLERS; ++i )
 	{
 		input_type[ i ] = RETRO_DEVICE_JOYPAD;
-		input_mode[ i ] = INPUT_MODE_3D_PAD_DEFAULT;
+		input_mode[ i ] = INPUT_MODE_DEFAULT;
 
 		SMPC_SetInput( i, "gamepad", (uint8*)&input_data[ i ] );
 	}
@@ -490,7 +487,7 @@ void retro_set_controller_port_device( unsigned in_port, unsigned device )
 	{
 		// Store input type
 		input_type[ in_port ] = device;
-		input_mode[ in_port ] = 0;
+		input_mode[ in_port ] = INPUT_MODE_DEFAULT;
 
 		switch ( device )
 		{
@@ -509,7 +506,7 @@ void retro_set_controller_port_device( unsigned in_port, unsigned device )
 		case RETRO_DEVICE_SS_3D_PAD:
 			log_cb( RETRO_LOG_INFO, "Controller %u: 3D Control Pad\n", (in_port+1) );
 			SMPC_SetInput( in_port, "3dpad", (uint8*)&input_data[ in_port ] );
-			input_mode[ in_port ] = INPUT_MODE_3D_PAD_DEFAULT;
+			input_mode[ in_port ] = INPUT_MODE_DEFAULT_3D_PAD;
 			break;
 
 		case RETRO_DEVICE_SS_WHEEL:

--- a/input.cpp
+++ b/input.cpp
@@ -19,6 +19,7 @@ static unsigned players = MAX_CONTROLLERS;
 
 static int astick_deadzone = 0;
 static int trigger_deadzone = 0;
+static bool virtua_gun_trigger_rmb = false;
 
 typedef union
 {
@@ -298,6 +299,11 @@ void input_set_deadzone_trigger( int percent )
 		trigger_deadzone = (int)( percent * 0.01f * 0x8000);
 }
 
+void input_set_virtua_gun_trigger( bool use_rmb )
+{
+	virtua_gun_trigger_rmb = use_rmb;
+}
+
 void input_update( retro_input_state_t input_state_cb )
 {
 	// For each player (logical controller)
@@ -558,43 +564,71 @@ void input_update( retro_input_state_t input_state_cb )
 
 			{
 				p_input->u8[0x4] = 0;
-
-				// trigger
-				if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER ) ) {
-					p_input->u8[0x4] |= 0x1; // Trigger
-				}
-
-				if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TURBO ) ) {
-					p_input->u8[0x4] |= 0x4; // Offscreen Shot(Simulated)
-
-				// start button
-				if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START ) ||
-					 input_state_cb( iplayer, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START ) ||
-					 input_state_cb( iplayer, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_BUTTON_4 ) ||
-					 input_state_cb( iplayer, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_BUTTON_5 ) )
-				{
-					p_input->u8[0x4] |= 0x2; // Start
-				}
+				uint8_t shot_type = 0;
 
 				// -- Position
 
-				int gun_x_raw, gun_y_raw;
-				gun_x_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X ) + 0x7fff;
-				gun_y_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y ) + 0x7fff;
-
-				// .. scale into screen space:
-				// NOTE: this is complete hacky guesswork for this first pass, need to re-write.
 				int gun_x, gun_y;
-				gun_x = ( gun_x_raw * 21472 ) / (0x7fff << 1);
-				gun_y = ( gun_y_raw * 240 ) / (0x7fff << 1);
+				int gun_x_raw, gun_y_raw;
+				gun_x_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X );
+				gun_y_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y );
 
+				int gun_edge_detect = 32700;
+
+				// off-screen?
+				if ( ( ( gun_x_raw == 0 ) && ( gun_y_raw == 0 ) ) ||
+					 ( gun_x_raw < -gun_edge_detect ) ||
+					 ( gun_x_raw > gun_edge_detect ) ||
+					 ( gun_y_raw < -gun_edge_detect ) ||
+					 ( gun_y_raw > gun_edge_detect ) )
+				{
+					shot_type = ( 1 << 2 ); // Off-screen shot
+
+					gun_x = -16384; // magic position to disable cross-hair drawing.
+					gun_y = -16384;
+				}
+				else
+				{
+					shot_type = ( 1 << 0 ); // On-screen shot!
+
+					// .. scale into screen space:
+					// NOTE: the scaling here is semi-guesswork, need to re-write.
+					// TODO: Test with PAL games.
+
+					const int scale_x = 21472;
+					const int offset_x = 60;
+					const int scale_y = 240;
+
+					gun_x = ( ( gun_x_raw + offset_x + 0x7fff ) * scale_x ) / (0x7fff << 1);
+					gun_y = ( ( gun_y_raw + 0x7fff ) * scale_y ) / (0x7fff << 1);
+				}
+
+				// position
 				p_input->gun_pos[ 0 ] = gun_x;
 				p_input->gun_pos[ 1 ] = gun_y;
 
-//				log_cb( RETRO_LOG_INFO, "Gun: %d, %d\n", gun_x, gun_y );
+				unsigned mbutton_trigger;
+				unsigned mbutton_start;
 
-				// .. simulated off-screen shot?
-				// p_input->u8[0x4] |= 0x4;
+				if ( virtua_gun_trigger_rmb ) {
+					mbutton_trigger = RETRO_DEVICE_ID_MOUSE_RIGHT;
+					mbutton_start = RETRO_DEVICE_ID_MOUSE_LEFT;
+				} else {
+					mbutton_trigger = RETRO_DEVICE_ID_MOUSE_LEFT;
+					mbutton_start = RETRO_DEVICE_ID_MOUSE_RIGHT;
+				}
+
+				// trigger
+				if ( input_state_cb( iplayer, RETRO_DEVICE_MOUSE, 0, mbutton_trigger ) ) {
+					p_input->u8[4] |= shot_type;
+				}
+
+				// start
+				if ( input_state_cb( iplayer, RETRO_DEVICE_MOUSE, 0, mbutton_start ) ||
+					 input_state_cb( iplayer, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START ) )
+				{
+					p_input->u8[0x4] |= ( 1 << 1 ); // Start Button
+				}
 			}
 
 			break;

--- a/input.cpp
+++ b/input.cpp
@@ -48,7 +48,6 @@ static uint32_t input_mode[ MAX_CONTROLLERS ] = {0};
 
 #define RETRO_DEVICE_SS_PAD			RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_JOYPAD, 0 )
 #define RETRO_DEVICE_SS_3D_PAD		RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_ANALOG, 0 )
-#define RETRO_DEVICE_SS_MOUSE		RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_MOUSE,  0 )
 #define RETRO_DEVICE_SS_WHEEL		RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_ANALOG, 1 )
 
 enum { INPUT_DEVICE_TYPES_COUNT = 1 /*none*/ + 3 }; // <-- update me!
@@ -58,7 +57,6 @@ static const struct retro_controller_description input_device_types[ INPUT_DEVIC
 	{ "Control Pad", RETRO_DEVICE_JOYPAD },
 	{ "3D Control Pad", RETRO_DEVICE_SS_3D_PAD },
 	{ "Arcade Racer", RETRO_DEVICE_SS_WHEEL },
-//	{ "Mouse", RETRO_DEVICE_SS_MOUSE }, // todo !
 	{ NULL, 0 },
 };
 
@@ -467,11 +465,6 @@ void retro_set_controller_port_device( unsigned in_port, unsigned device )
 			log_cb( RETRO_LOG_INFO, "Controller %u: 3D Control Pad\n", (in_port+1) );
 			SMPC_SetInput( in_port, "3dpad", (uint8*)&input_data[ in_port ] );
 			break;
-
-		/*case RETRO_DEVICE_SS_MOUSE:
-			log_cb( RETRO_LOG_INFO, "Controller %u: Mouse\n", (in_port+1) );
-			SMPC_SetInput( in_port, "mouse", (uint8*)&input_data[ in_port ] );
-			break;*/
 
 		case RETRO_DEVICE_SS_WHEEL:
 			log_cb( RETRO_LOG_INFO, "Controller %u: Arcade Racer\n", (in_port+1) );

--- a/input.cpp
+++ b/input.cpp
@@ -559,14 +559,18 @@ void input_update( retro_input_state_t input_state_cb )
 			{
 				p_input->u8[0x4] = 0;
 
-				// start button
-				if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START ) ) {
-					p_input->u8[0x4] |= 0x2; // Start
-				}
-
 				// trigger
 				if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER ) ) {
 					p_input->u8[0x4] |= 0x1; // Trigger
+				}
+
+				// start button
+				if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START ) ||
+					 input_state_cb( iplayer, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START ) ||
+					 input_state_cb( iplayer, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_BUTTON_4 ) ||
+					 input_state_cb( iplayer, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_BUTTON_5 ) )
+				{
+					p_input->u8[0x4] |= 0x2; // Start
 				}
 
 				// -- Position

--- a/input.cpp
+++ b/input.cpp
@@ -56,7 +56,7 @@ static uint16_t input_mode[ MAX_CONTROLLERS ] = {0};
 #define RETRO_DEVICE_SS_MOUSE		RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_MOUSE,  0 )
 #define RETRO_DEVICE_SS_GUN			RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_LIGHTGUN, 0 )
 
-enum { INPUT_DEVICE_TYPES_COUNT = 1 /*none*/ + 4 }; // <-- update me!
+enum { INPUT_DEVICE_TYPES_COUNT = 1 /*none*/ + 5 }; // <-- update me!
 
 static const struct retro_controller_description input_device_types[ INPUT_DEVICE_TYPES_COUNT ] =
 {

--- a/input.h
+++ b/input.h
@@ -15,6 +15,7 @@ extern void input_set_env( retro_environment_t environ_cb );
 
 extern void input_set_deadzone_stick( int percent );
 extern void input_set_deadzone_trigger( int percent );
+extern void input_set_virtua_gun_trigger( bool use_rmb );
 
 extern void input_update( retro_input_state_t input_state_cb );
 

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2640,6 +2640,15 @@ static void check_variables(bool startup)
 
 	if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value )
 		input_set_deadzone_trigger( atoi( var.value ) );
+
+	var.key = "beetle_saturn_virtuagun_trigger";
+	var.value = NULL;
+
+	if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value )
+	{
+		bool newval = (!strcmp(var.value, "Right Mouse Button"));
+		input_set_virtua_gun_trigger( newval );
+	}
 }
 
 #ifdef NEED_CD
@@ -3081,6 +3090,9 @@ void retro_set_environment( retro_environment_t cb )
    static const struct retro_variable vars[] = {
       { "beetle_saturn_region", "System Region; Auto Detect|Japan|North America|Europe|South Korea|Asia (NTSC)|Asia (PAL)|Brazil|Latin America" },
       { "beetle_saturn_cart", "Cartridge; Auto Detect|None|Backup Memory|Extended RAM (1MB)|Extended RAM (4MB)|The King of Fighters '95|Ultraman: Hikari no Kyojin Densetsu" },
+      { "beetle_saturn_analog_stick_deadzone", "3D Pad - Analog Deadzone; 15%|20%|25%|30%|0%|5%|10%"},
+      { "beetle_saturn_trigger_deadzone", "3D Pad - Trigger Deadzone; 15%|20%|25%|30%|0%|5%|10%"},
+      { "beetle_saturn_virtuagun_trigger", "Virtua Gun - Trigger; Left Mouse Button|Right Mouse Button" },
       { "beetle_saturn_cdimagecache", "CD Image Cache (restart); disabled|enabled" },
       { "beetle_saturn_autortc", "Automatically set RTC on game load; enabled|disabled" },
       { "beetle_saturn_autortc_lang", "BIOS language; english|german|french|spanish|italian|japanese" },
@@ -3090,8 +3102,6 @@ void retro_set_environment( retro_environment_t cb )
       { "beetle_saturn_initial_scanline_pal", "Initial scanline PAL; 16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60|0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15" },
       { "beetle_saturn_last_scanline_pal", "Last scanline PAL; 271|272|273|274|275|276|277|278|279|280|281|282|283|284|285|286|287|230|231|232|233|234|235|236|237|238|239|240|241|242|243|244|245|246|247|248|249|250|251|252|253|254|255|256|257|258|259|260|261|262|263|264|265|266|267|268|269|270" },
       { "beetle_saturn_horizontal_blend", "Enable Horizontal Blend(blur); disabled|enabled" },
-      { "beetle_saturn_analog_stick_deadzone", "Analog Deadzone (percent); 15|20|25|30|0|5|10"},
-      { "beetle_saturn_trigger_deadzone", "Trigger Deadzone (percent); 15|20|25|30|0|5|10"},
       { NULL, NULL },
    };
 


### PR DESCRIPTION
This patch adds support for the Virtua Gun (known as the Stunner in North America).

As you can see this took a little while to get this right. Thanks to @retro-wertz for helping tune the cursor position.

It works really well with a Dolphin Bar and a Wiimote in a plastic gun shell. Set the bar to 'mode 2' and Wiimote B is fire, A is start/pause. You even have to aim off-screen to reload (works best if you're running full-screen or the mouse clicks generated by the sensor bar will end up as clicks on the desktop / other windows!)