### PR TITLE
Updated dual mission stick layout to match patent

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -818,10 +818,12 @@ void input_update( retro_input_state_t input_state_cb )
 				// -- analog sticks
 
 				int analog1_x, analog1_y;
-				get_analog_stick( input_state_cb, iplayer, RETRO_DEVICE_INDEX_ANALOG_LEFT, &analog1_x, &analog1_y );
-
 				int analog2_x, analog2_y;
-				get_analog_stick( input_state_cb, iplayer, RETRO_DEVICE_INDEX_ANALOG_RIGHT, &analog2_x, &analog2_y );
+
+				// Default - patent shows first stick on right side, second added on left
+				// see: https://segaretro.org/images/a/a1/Patent_EP0745928A2.pdf
+				get_analog_stick( input_state_cb, iplayer, RETRO_DEVICE_INDEX_ANALOG_RIGHT, &analog1_x, &analog1_y );
+				get_analog_stick( input_state_cb, iplayer, RETRO_DEVICE_INDEX_ANALOG_LEFT, &analog2_x, &analog2_y );
 
 				//
 				// -- format input data


### PR DESCRIPTION
This is a correction for my previous dual-mission stick support patch from last night.

After studying the patent for the sticks in this configuration:
https://segaretro.org/images/a/a1/Patent_EP0745928A2.pdf

It shows the main stick on the right and an additional stick added onto the left of the unit.
This means that my previous patch was incorrect.

This tallies with playing Panzer Dragoon Zwei (the only known game which supports this dual stick configuration)  In single stick mode, the main stick is for aiming in-game and in dual stick mode the additional (now on the left) stick becomes the aiming stick. If you're using a 360 controller to emulate this, switching to dual mode adds extra functionality to the right stick (moving the dragon independently) while maintaining left stick to aim - which is more consistent.

n.b. If this orientation fix is not preferred, the input remapping code can be used to swap it back, but from my research this new patch represents the intended configuration for dual stick mode.