### PR TITLE
MSVC compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.o
+*.dll
+*.pdb
+*.lib
+*.exp
+*.manifest

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,13 @@ HAVE_CHD = 1
 CORE_DIR := .
 HAVE_GRIFFIN = 0
 
+SPACE :=
+SPACE := $(SPACE) $(SPACE)
+BACKSLASH :=
+BACKSLASH := \$(BACKSLASH)
+filter_out1 = $(filter-out $(firstword $1),$1)
+filter_out2 = $(call filter_out1,$(call filter_out1,$1))
+
 ifeq ($(platform),)
    platform = unix
    ifeq ($(shell uname -a),)
@@ -305,6 +312,95 @@ ifeq ($(HAVE_OPENGL),1)
 	endif
 endif
 
+# Windows MSVC 2017 all architectures
+else ifneq (,$(findstring windows_msvc2017,$(platform)))
+
+    NO_GCC := 1
+    FLAGS += -DHAVE__MKDIR
+
+	PlatformSuffix = $(subst windows_msvc2017_,,$(platform))
+	ifneq (,$(findstring desktop,$(PlatformSuffix)))
+		WinPartition = desktop
+		MSVC2017CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP -FS
+		LDFLAGS += -MANIFEST -LTCG:incremental -NXCOMPAT -DYNAMICBASE -DEBUG -OPT:REF -INCREMENTAL:NO -SUBSYSTEM:WINDOWS -MANIFESTUAC:"level='asInvoker' uiAccess='false'" -OPT:ICF -ERRORREPORT:PROMPT -NOLOGO -TLBID:1
+		LIBS += kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib
+	else ifneq (,$(findstring uwp,$(PlatformSuffix)))
+		WinPartition = uwp
+		MSVC2017CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_APP -DWINDLL -D_UNICODE -DUNICODE -DWRL_NO_DEFAULT_LIB -FS
+		LDFLAGS += -APPCONTAINER -NXCOMPAT -DYNAMICBASE -MANIFEST:NO -LTCG -OPT:REF -SUBSYSTEM:CONSOLE -MANIFESTUAC:NO -OPT:ICF -ERRORREPORT:PROMPT -NOLOGO -TLBID:1 -DEBUG:FULL -WINMD:NO
+		LIBS += WindowsApp.lib
+	endif
+
+	CFLAGS += $(MSVC2017CompileFlags)
+	CXXFLAGS += $(MSVC2017CompileFlags)
+
+	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
+
+	CC  = cl.exe
+	CXX = cl.exe
+	LD = link.exe
+
+	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
+	fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
+
+	ProgramFiles86w := $(shell cmd /c "echo %PROGRAMFILES(x86)%")
+	ProgramFiles86 := $(shell cygpath "$(ProgramFiles86w)")
+
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_CURRENT_USER\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir := $(WindowsSdkDir)
+
+	WindowsSDKVersion ?= $(firstword $(foreach folder,$(subst $(subst \,/,$(WindowsSdkDir)Include/),,$(wildcard $(call fix_path,$(WindowsSdkDir)Include\*))),$(if $(wildcard $(call fix_path,$(WindowsSdkDir)Include/$(folder)/um/Windows.h)),$(folder),)))$(BACKSLASH)
+	WindowsSDKVersion := $(WindowsSDKVersion)
+
+	VsInstallBuildTools = $(ProgramFiles86)/Microsoft Visual Studio/2017/BuildTools
+	VsInstallEnterprise = $(ProgramFiles86)/Microsoft Visual Studio/2017/Enterprise
+	VsInstallProfessional = $(ProgramFiles86)/Microsoft Visual Studio/2017/Professional
+	VsInstallCommunity = $(ProgramFiles86)/Microsoft Visual Studio/2017/Community
+
+	VsInstallRoot ?= $(shell if [ -d "$(VsInstallBuildTools)" ]; then echo "$(VsInstallBuildTools)"; fi)
+	ifeq ($(VsInstallRoot), )
+		VsInstallRoot = $(shell if [ -d "$(VsInstallEnterprise)" ]; then echo "$(VsInstallEnterprise)"; fi)
+	endif
+	ifeq ($(VsInstallRoot), )
+		VsInstallRoot = $(shell if [ -d "$(VsInstallProfessional)" ]; then echo "$(VsInstallProfessional)"; fi)
+	endif
+	ifeq ($(VsInstallRoot), )
+		VsInstallRoot = $(shell if [ -d "$(VsInstallCommunity)" ]; then echo "$(VsInstallCommunity)"; fi)
+	endif
+	VsInstallRoot := $(VsInstallRoot)
+
+	VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
+	VcCompilerToolsDir := $(VsInstallRoot)/VC/Tools/MSVC/$(VcCompilerToolsVer)
+
+	WindowsSDKSharedIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\shared")
+	WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
+	WindowsSDKUMIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\um")
+	WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\$(TargetArchMoniker)")
+	WindowsSDKUMLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\um\$(TargetArchMoniker)")
+
+	# For some reason the HostX86 compiler doesn't like compiling for x64
+	# ("no such file" opening a shared library), and vice-versa.
+	# Work around it for now by using the strictly x86 compiler for x86, and x64 for x64.
+	# NOTE: What about ARM?
+	ifneq (,$(findstring x64,$(TargetArchMoniker)))
+		VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\HostX64
+	else
+		VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\HostX86
+	endif
+
+	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/$(TargetArchMoniker)"):$(PATH)
+	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
+	INCLUDE := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/include")
+	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/lib/$(TargetArchMoniker)")
+
+	export INCLUDE := $(INCLUDE);$(WindowsSDKSharedIncludeDir);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir)
+	export LIB := $(LIB);$(WindowsSDKUCRTLibDir);$(WindowsSDKUMLibDir)
+	TARGET := $(TARGET_NAME)_libretro.dll
+	PSS_STYLE :=2
+	LDFLAGS += -DLL
 
 # Windows
 else
@@ -365,18 +461,29 @@ endif
 CXXFLAGS += $(FLAGS) -std=c++11
 CFLAGS   += $(FLAGS)
 
+OBJOUT   = -o
+LINKOUT  = -o 
+
+ifneq (,$(findstring msvc,$(platform)))
+	OBJOUT = -Fo
+	LINKOUT = -out:
+	LD = link.exe
+else
+	LD = $(CXX)
+endif
+
 $(TARGET): $(OBJECTS)
 ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 else
-	$(CXX) -o $@ $^ $(LDFLAGS) $(GL_LIB)
+	$(LD) $(LINKOUT)$@ $^ $(LDFLAGS) $(GL_LIB) $(LIBS)
 endif
 
 %.o: %.cpp
-	$(CXX) -c -o $@ $< $(CXXFLAGS)
+	$(CXX) -c $(OBJOUT)$@ $< $(CXXFLAGS)
 
 %.o: %.c
-	$(CC) -c -o $@ $< $(CFLAGS)
+	$(CC) -c $(OBJOUT)$@ $< $(CFLAGS)
 
 clean:
 	rm -f $(TARGET) $(OBJECTS)

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ endif
 else ifneq (,$(findstring windows_msvc2017,$(platform)))
 
     NO_GCC := 1
-    FLAGS += -DHAVE__MKDIR
+    FLAGS += -DHAVE__MKDIR -DNOMINMAX
 
 	PlatformSuffix = $(subst windows_msvc2017_,,$(platform))
 	ifneq (,$(findstring desktop,$(PlatformSuffix)))
@@ -332,7 +332,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	endif
 
 	CFLAGS += $(MSVC2017CompileFlags)
-	CXXFLAGS += $(MSVC2017CompileFlags)
+	CXXFLAGS += $(MSVC2017CompileFlags) -EHsc
 
 	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
 
@@ -458,8 +458,12 @@ ifeq ($(HAVE_JIT),1)
    LDFLAGS += -ljit
 endif
 
-CXXFLAGS += $(FLAGS) -std=c++11
+CXXFLAGS += $(FLAGS)
 CFLAGS   += $(FLAGS)
+
+ifeq (,$(findstring msvc,$(platform)))
+    CXXFLAGS += -std=c++11
+endif
 
 OBJOUT   = -o
 LINKOUT  = -o 

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ endif
 else ifneq (,$(findstring windows_msvc2017,$(platform)))
 
     NO_GCC := 1
-    FLAGS += -DHAVE__MKDIR -DNOMINMAX
+    FLAGS += -DHAVE__MKDIR -DNOMINMAX -D__PIC__
 
 	PlatformSuffix = $(subst windows_msvc2017_,,$(platform))
 	ifneq (,$(findstring desktop,$(PlatformSuffix)))
@@ -331,10 +331,20 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 		LIBS += WindowsApp.lib
 	endif
 
+	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
+
+    ifneq (,$(findstring x64,$(TargetArchMoniker)))
+		MSVC2017CompileFlags += -D__x86_64__
+	endif
+    ifneq (,$(findstring x86,$(TargetArchMoniker)))
+		MSVC2017CompileFlags += -D__i386__
+	endif
+    ifneq (,$(findstring arm,$(TargetArchMoniker)))
+		MSVC2017CompileFlags += -D__arm__
+	endif
+
 	CFLAGS += $(MSVC2017CompileFlags)
 	CXXFLAGS += $(MSVC2017CompileFlags) -EHsc
-
-	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
 
 	CC  = cl.exe
 	CXX = cl.exe

--- a/Makefile.common
+++ b/Makefile.common
@@ -190,7 +190,7 @@ SOURCES_C += \
 	$(DEPS_DIR)/libchdr/flac.c \
 	$(DEPS_DIR)/libchdr/huffman.c 
 
-   ifeq ($(platform), win)
+   ifneq (,$(findstring win,$(platform)))
        SOURCES_C += $(DEPS_DIR)/flac-1.3.2/src/libFLAC/windows_unicode_filenames.c
    endif
 

--- a/mednafen/ss/cdb.cpp
+++ b/mednafen/ss/cdb.cpp
@@ -951,6 +951,8 @@ static bool FLS_Run(void)
   goto Abort;
  }
 
+ static const char stdid[5] = { 'C', 'D', '0', '0', '1' };
+
  //
  FLS_PROLOGUE;
  //
@@ -963,7 +965,6 @@ static bool FLS_Run(void)
 
    for(;;)
    {
-    static const char stdid[5] = { 'C', 'D', '0', '0', '1' };
     FLS_WAIT_GRAB_BUF;
 
     if(memcmp(FLS.pbuf + 1, stdid, 5) || FLS.pbuf[0] == 0xFF)

--- a/mednafen/ss/scu_dsp_gen.cpp
+++ b/mednafen/ss/scu_dsp_gen.cpp
@@ -22,7 +22,10 @@
 #include "ss.h"
 #include "scu.h"
 
+#ifndef _MSC_VER
 #pragma GCC optimize("Os")
+#endif
+
   // Is first DSP instruction cached on PC load, or when execution starts?
 
   // MOV [s],[d] s=0x8 = 0xFFFFFFFF?

--- a/mednafen/ss/ss_memory.h
+++ b/mednafen/ss/ss_memory.h
@@ -32,7 +32,7 @@
 // "Array" is a bit of a misnomer, but it helps avoid confusion with memset() semantics hopefully.
 static INLINE void MDFN_FastArraySet(uint64* const dst, const uint64 value, const size_t count)
 {
- #if defined(__x86_64__)
+ #if defined(__x86_64__) && !defined(_MSC_VER)
  {
   uint32 dummy_output0, dummy_output1;
 
@@ -53,7 +53,7 @@ static INLINE void MDFN_FastArraySet(uint64* const dst, const uint64 value, cons
 
 static INLINE void MDFN_FastArraySet(uint32* const dst, const uint32 value, const size_t count)
 {
- #if defined(__x86_64__)
+ #if defined(__x86_64__) && !defined(_MSC_VER)
  {
   uint32 dummy_output0, dummy_output1;
 

--- a/mednafen/state.h
+++ b/mednafen/state.h
@@ -121,12 +121,9 @@ static INLINE SFORMAT SFBASE_(T* const v, const uint32 count, const char* const 
 #define SFVAR1_(x)	   SFVARN((x), #x)
 #define SFVAR3_(x, tc, rs) SFVARN((x), tc, rs, #x)
 #define SFVAR_(a, b, c, d, ...)	d
-#ifdef _MSC_VER
+
 #define EXPAND( x ) x
 #define SFVAR(...) 	EXPAND(SFVAR_(__VA_ARGS__, SFVAR3_, SFVAR2_, SFVAR1_, SFVAR0_)(__VA_ARGS__))
-#else
-#define SFVAR(...) 	SFVAR_(__VA_ARGS__, SFVAR3_, SFVAR2_, SFVAR1_, SFVAR0_)(__VA_ARGS__)
-#endif
 
 #if SIZEOF_DOUBLE != 8
  #error "sizeof(double) != 8"

--- a/mednafen/state.h
+++ b/mednafen/state.h
@@ -121,7 +121,12 @@ static INLINE SFORMAT SFBASE_(T* const v, const uint32 count, const char* const 
 #define SFVAR1_(x)	   SFVARN((x), #x)
 #define SFVAR3_(x, tc, rs) SFVARN((x), tc, rs, #x)
 #define SFVAR_(a, b, c, d, ...)	d
+#ifdef _MSC_VER
+#define EXPAND( x ) x
+#define SFVAR(...) 	EXPAND(SFVAR_(__VA_ARGS__, SFVAR3_, SFVAR2_, SFVAR1_, SFVAR0_)(__VA_ARGS__))
+#else
 #define SFVAR(...) 	SFVAR_(__VA_ARGS__, SFVAR3_, SFVAR2_, SFVAR1_, SFVAR0_)(__VA_ARGS__)
+#endif
 
 #if SIZEOF_DOUBLE != 8
  #error "sizeof(double) != 8"


### PR DESCRIPTION
Added MSVC2017 compile target and some code changes to make core compile
HOWEVER
When run it keeps crashing with the following error:

```
Assertion failed!

Program: ...jects\RetroArch\cores\mednafen_saturn_libretro.dll
File: c:\users\alberto\documents\projects\libretror.../scu.inc
Line: 1716

Expression: (uintptr_t)f == DSP_INSTR_BASE_UIPT + ((uintptr_t)(DSP_INSTR_RECOVER_TCAST)(uint32)((uintptr_t)f - DSP_INSTR_BASE_UIPT))
```

Testing against Retroarch 64bit (compiling core with platform=windows_msvc2017_desktop_x64). The same code when compiled in GCC (without specifying platform) works.

Can someone help me figure out what's going wrong?