### PR TITLE
Fully initialise av_info structure

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2259,6 +2259,8 @@ void retro_run(void)
       // This avoids inconsistent frame scales when game switches between interlaced and non-interlaced modes.
       av_info.geometry.base_width   = 352 - h_mask;
       av_info.geometry.base_height  = linevislast + 1 - linevisfirst;
+      av_info.geometry.max_width    = MEDNAFEN_CORE_GEOMETRY_MAX_W;
+      av_info.geometry.max_height   = MEDNAFEN_CORE_GEOMETRY_MAX_H;
       av_info.geometry.aspect_ratio = MEDNAFEN_CORE_GEOMETRY_ASPECT_RATIO;
       environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
 


### PR DESCRIPTION
The av_info structure passed back to the front-end does not initialise the complete structure, i.e. the max width/height fields are not set. Although technically (according to the libretro.h spec) these fields are not intended to be read by a RETRO_ENVIRONMENT_SET_GEOMETRY call, having uninitialised data like this is not robust and is an accident waiting to happen imo.