### PR TITLE
Libretro.cpp

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2324,7 +2324,11 @@ void retro_deinit(void)
 
 unsigned retro_get_region(void)
 {
-   return RETRO_REGION_NTSC;
+   If (content_is_pal == true){
+       return RETRO_REGION_PAL;  //Ben Swith PAL
+   }else{
+       return RETRO_REGION_NTSC;
+   }
 }
 
 unsigned retro_api_version(void)


### PR DESCRIPTION
There was no detection within libretro.cpp for PAL switch. Added a trigger content_is_pal bool  to return the correct region.

unsigned retro_get_region(void)
{
   If (content_is_pal == true){
       return RETRO_REGION_PAL;  
   }else{
       return RETRO_REGION_NTSC;
   }
}