### PR TITLE
Core now reports its name as "Beetle Saturn"

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -29,8 +29,7 @@
 
 #include <zlib.h>
 
-#define MEDNAFEN_CORE_NAME_MODULE            "ss"
-#define MEDNAFEN_CORE_NAME                   "Mednafen Saturn"
+#define MEDNAFEN_CORE_NAME                   "Beetle Saturn"
 #define MEDNAFEN_CORE_VERSION                "v0.9.48"
 #define MEDNAFEN_CORE_EXTENSIONS             "cue|ccd|chd|toc|m3u"
 #define MEDNAFEN_CORE_TIMING_FPS             59.82


### PR DESCRIPTION
Makes the core return the string "Beetle Saturn" as its name. Matches the name of the repo, and mirrors the change made to other cores derived from the Mednafen project.