### PR TITLE
Fix crash caused by WAV/WAVE/PCM files in cue sheet. Fixes #23.

### DIFF
--- a/mednafen/cdrom/CDAccess_Image.cpp
+++ b/mednafen/cdrom/CDAccess_Image.cpp
@@ -694,7 +694,11 @@ bool CDAccess_Image::ImageOpen(const std::string& path, bool image_memcache)
                //fstat(fileno(TmpTrack.fp), &stat_buf);
                //TmpTrack.sectors = stat_buf.st_size; // / 2048;
             }
-            else if(!strcasecmp(args[1].c_str(), "OGG") || !strcasecmp(args[1].c_str(), "VORBIS") || !strcasecmp(args[1].c_str(), "WAVE") || !strcasecmp(args[1].c_str(), "WAV") || !strcasecmp(args[1].c_str(), "PCM")
+            else if(!strcasecmp(args[1].c_str(), "WAVE") || !strcasecmp(args[1].c_str(), "WAV") || !strcasecmp(args[1].c_str(), "PCM"))
+            {
+               // Make it work with WAVE / WAV / PCM file type names in the cue sheet, previously .wav was working only with BINARY
+            }
+            else if(!strcasecmp(args[1].c_str(), "OGG") || !strcasecmp(args[1].c_str(), "VORBIS")
                   || !strcasecmp(args[1].c_str(), "MPC") || !strcasecmp(args[1].c_str(), "MP+"))
             {
                TmpTrack.AReader = CDAFR_Open(TmpTrack.fp);


### PR DESCRIPTION
[A similar approach](https://github.com/libretro/beetle-pce-fast-libretro/pull/53) was used to fix the same crash in the PC Engine version. It's worth noting that it will still crash if one tries to open a cue sheet with MPC files if HAVE_MPC isn't set, or one with OGG files if HAVE_MPC is set.