### PR TITLE
Use actual resolution for output image size & simplify core options

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -41,6 +41,29 @@
 #define MEDNAFEN_CORE_GEOMETRY_ASPECT_RATIO  (4.0 / 3.0)
 #define FB_WIDTH                             MEDNAFEN_CORE_GEOMETRY_MAX_W
 
+extern uint8 VRes; // in vdp2_render.cpp
+static const unsigned g_vertical_resolutions[ 4 ] =
+{
+	224,
+	240,
+	256,
+	288, // <-- invalid, safe default
+};
+static const unsigned g_vertical_line_skip_ntsc[ 4 ] =
+{
+	8,
+	0,
+	0,
+	0, // <-- invalid, safe default
+};
+static const unsigned g_vertical_line_skip_pal[ 4 ] =
+{
+	32,
+	24,
+	16,
+	0, // <-- invalid, safe default
+};
+
 struct retro_perf_callback perf_cb;
 retro_get_cpu_features_t perf_get_cpu_features_cb = NULL;
 retro_log_printf_t log_cb;
@@ -56,7 +79,6 @@ static bool failed_init = false;
 static unsigned image_offset = 0;
 static unsigned image_crop = 0;
 
-static unsigned h_mask = 0;
 static unsigned first_sl = 0;
 static unsigned last_sl = 239;
 static unsigned first_sl_pal = 0;
@@ -1148,14 +1170,12 @@ static bool InitCommon(const unsigned cpucache_emumode, const unsigned cart_type
    {
       const bool correct_aspect = MDFN_GetSettingB("ss.correct_aspect");
       const bool h_overscan = MDFN_GetSettingB("ss.h_overscan");
-      const bool h_blend = MDFN_GetSettingB("ss.h_blend");
 
       MDFN_printf(_("Displayed scanlines: [%u,%u]\n"), sls, sle);
       MDFN_printf(_("Correct Aspect Ratio: %s\n"), correct_aspect ? _("Enabled") : _("Disabled"));
       MDFN_printf(_("Show H Overscan: %s\n"), h_overscan ? _("Enabled") : _("Disabled"));
-      MDFN_printf(_("H Blend: %s\n"), h_blend ? _("Enabled") : _("Disabled"));
 
-      VDP2::SetGetVideoParams(&EmulatedSS, correct_aspect, sls, sle, h_overscan, h_blend);
+      VDP2::SetGetVideoParams(&EmulatedSS, correct_aspect, sls, sle, h_overscan, false);
    }
 
    MDFN_printf("\n");
@@ -1914,49 +1934,6 @@ static void check_variables(bool startup)
           setting_smpc_autortc_lang = 5;
    }
 
-   var.key = "beetle_saturn_horizontal_overscan";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      h_mask = atoi(var.value);
-   }
-
-   var.key = "beetle_saturn_initial_scanline";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      first_sl = atoi(var.value);
-   }
-
-   var.key = "beetle_saturn_last_scanline";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      last_sl = atoi(var.value);
-   }
-
-   var.key = "beetle_saturn_initial_scanline_pal";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      first_sl_pal = atoi(var.value);
-   }
-
-   var.key = "beetle_saturn_last_scanline_pal";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      last_sl_pal = atoi(var.value);
-   }
-
-   var.key = "beetle_saturn_horizontal_blend";
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      bool newval = (!strcmp(var.value, "enabled"));
-      DoHBlend = newval;
-   }
-
    var.key = "beetle_saturn_analog_stick_deadzone";
    var.value = NULL;
 
@@ -2187,16 +2164,12 @@ void retro_run(void)
 {
    bool updated = false;
    bool hires_h_mode;
-   unsigned overscan_mask;
-   unsigned linevisfirst, linevislast;
+   unsigned linevisfirst;
    static unsigned width, height;
    static unsigned game_width, game_height;
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
       check_variables(false);
-
-   linevisfirst   =  is_pal ? first_sl_pal : first_sl;
-   linevislast    =  is_pal ? last_sl_pal : last_sl;
 
    // Keep the counters at 0 so that they don't display a bogus
    // value if this option is enabled later on
@@ -2254,25 +2227,24 @@ void retro_run(void)
    const uint32_t *pix = surf->pixels;
    size_t pitch        = FB_WIDTH * sizeof(uint32_t);
 
-   hires_h_mode   =  (rects[0] == 704) ? true : false;
-   overscan_mask  =  (h_mask >> 1) << hires_h_mode;
-   width          =  rects[0] - (h_mask << hires_h_mode);
-   height         =  (linevislast + 1 - linevisfirst) << PrevInterlaced;
+   width          =  rects[0];
+   height         =  g_vertical_resolutions[VRes] << PrevInterlaced;
+   linevisfirst   =  is_pal ? g_vertical_line_skip_pal[VRes]
+   							: g_vertical_line_skip_ntsc[VRes];
 
+   // Changed?
    if (width != game_width || height != game_height)
    {
       struct retro_system_av_info av_info;
 
-      // Change frontend resolution using  base width/height (+ overscan adjustments).
-      // This avoids inconsistent frame scales when game switches between interlaced and non-interlaced modes.
-      av_info.geometry.base_width   = 352 - h_mask;
-      av_info.geometry.base_height  = linevislast + 1 - linevisfirst;
+      av_info.geometry.base_width   = width;
+      av_info.geometry.base_height  = height;
       av_info.geometry.max_width    = MEDNAFEN_CORE_GEOMETRY_MAX_W;
       av_info.geometry.max_height   = MEDNAFEN_CORE_GEOMETRY_MAX_H;
       av_info.geometry.aspect_ratio = MEDNAFEN_CORE_GEOMETRY_ASPECT_RATIO;
       environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
 
-      log_cb(RETRO_LOG_INFO, "Target framebuffer size : %dx%d\n", width, height);
+		log_cb(RETRO_LOG_INFO, "av_info.geometry.base_width/base_height : %d x %d (is_pal=%d)\n", width, height, is_pal);
 
       game_width  = width;
       game_height = height;
@@ -2280,7 +2252,7 @@ void retro_run(void)
       input_set_geometry( width, height );
    }
 
-   pix += surf->pitchinpix * (linevisfirst << PrevInterlaced) + overscan_mask;
+   pix += surf->pitchinpix * (linevisfirst << PrevInterlaced);
 
    fb = pix;
 
@@ -2361,16 +2333,10 @@ void retro_set_environment( retro_environment_t cb )
       { "beetle_saturn_trigger_deadzone", "Trigger Deadzone; 15%|20%|25%|30%|0%|5%|10%"},
       { "beetle_saturn_mouse_sensitivity", "Mouse Sensitivity; 100%|105%|110%|115%|120%|125%|130%|135%|140%|145%|150%|155%|160%|165%|170%|175%|180%|185%|190%|195%|200%|5%|10%|15%|20%|25%|30%|35%|40%|45%|50%|55%|60%|65%|70%|75%|80%|85%|90%|95%" },
       { "beetle_saturn_virtuagun_crosshair", "Gun Crosshair; Cross|Dot|Off" },
-      { "beetle_saturn_cdimagecache", "CD Image Cache (restart); disabled|enabled" },
+      { "beetle_saturn_cdimagecache", "CD Image Cache (restart); enabled|disabled" },
       { "beetle_saturn_midsync", "Mid-frame Input Synchronization; disabled|enabled" },
       { "beetle_saturn_autortc", "Automatically set RTC on game load; enabled|disabled" },
       { "beetle_saturn_autortc_lang", "BIOS language; english|german|french|spanish|italian|japanese" },
-      { "beetle_saturn_horizontal_overscan", "Horizontal Overscan Mask; 0|2|4|6|8|10|12|14|16|18|20|22|24|26|28|30|32|34|36|38|40|42|44|46|48|50|52|54|56|58|60" },
-      { "beetle_saturn_initial_scanline", "Initial scanline; 0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40" },
-      { "beetle_saturn_last_scanline", "Last scanline; 239|210|211|212|213|214|215|216|217|218|219|220|221|222|223|224|225|226|227|228|229|230|231|232|233|234|235|236|237|238" },
-      { "beetle_saturn_initial_scanline_pal", "Initial scanline PAL; 16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60|0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15" },
-      { "beetle_saturn_last_scanline_pal", "Last scanline PAL; 271|272|273|274|275|276|277|278|279|280|281|282|283|284|285|286|287|230|231|232|233|234|235|236|237|238|239|240|241|242|243|244|245|246|247|248|249|250|251|252|253|254|255|256|257|258|259|260|261|262|263|264|265|266|267|268|269|270" },
-      { "beetle_saturn_horizontal_blend", "Enable Horizontal Blend(blur); disabled|enabled" },
       { NULL, NULL },
    };
 

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -44,6 +44,7 @@
 bool g_cropped_height = false;
 
 extern uint8 VRes; // in vdp2_render.cpp
+extern bool CorrectAspect; // in vdp2_render.cpp
 
 static const unsigned g_vertical_resolutions[ 4 ] = { 224, 240, 256, 288 };
 static const unsigned g_vertical_line_skip_crop_ntsc[ 4 ] = { 8, 0, 0, 0 };
@@ -1953,6 +1954,26 @@ static void check_variables(bool startup)
          setting_gun_crosshair = SETTING_GUN_CROSSHAIR_DOT;
       }
    }
+
+   var.key = "beetle_saturn_crop_h";
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "enabled"))
+         CorrectAspect = true;
+      else if (!strcmp(var.value, "disabled"))
+         CorrectAspect = false;
+   }
+
+   var.key = "beetle_saturn_crop_v";
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "enabled"))
+         g_cropped_height = true;
+      else if (!strcmp(var.value, "disabled"))
+         g_cropped_height = false;
+   }
 }
 
 static bool MDFNI_LoadGame( const char *name )
@@ -2340,6 +2361,8 @@ void retro_set_environment( retro_environment_t cb )
       { "beetle_saturn_midsync", "Mid-frame Input Synchronization; disabled|enabled" },
       { "beetle_saturn_autortc", "Automatically set RTC on game load; enabled|disabled" },
       { "beetle_saturn_autortc_lang", "BIOS language; english|german|french|spanish|italian|japanese" },
+      { "beetle_saturn_crop_h", "Remove Horizontal Borders; disabled|enabled" },
+      { "beetle_saturn_crop_v", "Remove Vertical Borders; disabled|enabled" },
       { NULL, NULL },
    };
 

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -33,7 +33,6 @@
 #define MEDNAFEN_CORE_VERSION                "v0.9.48"
 #define MEDNAFEN_CORE_VERSION_NUMERIC        0x00094800 // 0x00102100
 #define MEDNAFEN_CORE_EXTENSIONS             "cue|ccd|chd|toc|m3u"
-#define MEDNAFEN_CORE_TIMING_FPS             59.82
 #define MEDNAFEN_CORE_GEOMETRY_BASE_W        320
 #define MEDNAFEN_CORE_GEOMETRY_BASE_H        240
 #define MEDNAFEN_CORE_GEOMETRY_MAX_W         704
@@ -2350,10 +2349,12 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    
    info->geometry.aspect_ratio = 4.0f / 3.0f;
 
-   if (retro_get_region() == RETRO_REGION_PAL)
+   if (is_pal)
       info->timing.fps            = 49.96;
    else
       info->timing.fps            = 59.88;
+      
+   log_cb(RETRO_LOG_INFO, "info->timing.fps = %f\n", info->timing.fps);
 }
 
 void retro_deinit(void)

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2394,7 +2394,7 @@ void retro_set_environment( retro_environment_t cb )
       { "beetle_saturn_trigger_deadzone", "Trigger Deadzone; 15%|20%|25%|30%|0%|5%|10%"},
       { "beetle_saturn_mouse_sensitivity", "Mouse Sensitivity; 100%|105%|110%|115%|120%|125%|130%|135%|140%|145%|150%|155%|160%|165%|170%|175%|180%|185%|190%|195%|200%|5%|10%|15%|20%|25%|30%|35%|40%|45%|50%|55%|60%|65%|70%|75%|80%|85%|90%|95%" },
       { "beetle_saturn_virtuagun_crosshair", "Gun Crosshair; Cross|Dot|Off" },
-      { "beetle_saturn_cdimagecache", "CD Image Cache (restart); enabled|disabled" },
+      { "beetle_saturn_cdimagecache", "CD Image Cache (restart); disabled|enabled" },
       { "beetle_saturn_midsync", "Mid-frame Input Synchronization; disabled|enabled" },
       { "beetle_saturn_autortc", "Automatically set RTC on game load; enabled|disabled" },
       { "beetle_saturn_autortc_lang", "BIOS language; english|german|french|spanish|italian|japanese" },

--- a/mednafen/settings.h
+++ b/mednafen/settings.h
@@ -3,8 +3,6 @@
 
 #include <string>
 
-extern bool DoHBlend;
-
 // This should assert() or something if the setting isn't found, since it would
 // be a totally tubular error!
 uint64 MDFN_GetSettingUI(const char *name);

--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -40,7 +40,7 @@
 
 static EmulateSpecStruct* espec = NULL;
 static bool PAL;
-static bool CorrectAspect = true;
+bool CorrectAspect = true;
 static bool ShowHOverscan = true;
 static int LineVisFirst, LineVisLast;
 static uint32_t NextOutLine;


### PR DESCRIPTION
Experimental patch - testing required!

This patch reports the actual resolution of the Saturn frame buffer as the output geometry size. 320 and 352 pixel wide modes are supported as are the 224, 240 and 256 line modes (plus x2 with interlacing)

The front-end is always told that it needs a 4:3 aspect ratio, so should scale the pixels as required.

I've also removed a number of settings that are no longer required such as the start/end line, hblend (which is duplicating work the shaders can do) and hmask which trims the front/back porch and is no longer needed.