### PR TITLE
Mednafen 1.21.3 sync

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -30,8 +30,8 @@ static INLINE bool DBG_NeedCPUHooks(void) { return false; } // <-- replaces debu
 #include <zlib.h>
 
 #define MEDNAFEN_CORE_NAME                   "Beetle Saturn"
-#define MEDNAFEN_CORE_VERSION                "v1.21.2"
-#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102102
+#define MEDNAFEN_CORE_VERSION                "v1.21.3"
+#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102103
 #define MEDNAFEN_CORE_EXTENSIONS             "cue|ccd|chd|toc|m3u"
 #define MEDNAFEN_CORE_TIMING_FPS             59.82
 #define MEDNAFEN_CORE_GEOMETRY_BASE_W        320

--- a/mednafen/ss/db.cpp
+++ b/mednafen/ss/db.cpp
@@ -142,6 +142,7 @@ static const struct
  { "T-18504G", CPUCACHE_EMUMODE_DATA_CB },	// Father Christmas (Japan)
  { "MK-81045", CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Europe) (and USA too?)
  { "GS-9041",	CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Japan)
+ { "GS-9173", CPUCACHE_EMUMODE_DATA_CB },	// House of the Dead (Japan)
  { "81600",	CPUCACHE_EMUMODE_DATA_CB },	// Sega Saturn Choice Cuts (USA)
  { "610680501",CPUCACHE_EMUMODE_DATA_CB },	// Segakore Sega Bible Mogitate SegaSaturn
  { "T-7001H",	CPUCACHE_EMUMODE_DATA_CB },	// Spot Goes to Hollywood (USA)
@@ -150,7 +151,13 @@ static const struct
  { "T-1206G",	CPUCACHE_EMUMODE_DATA_CB },	// Street Fighter Zero (Japan)
  { "T-1246G",	CPUCACHE_EMUMODE_DATA_CB },	// Street Fighter Zero 3 (Japan)
  { "T-1215H",	CPUCACHE_EMUMODE_DATA_CB },	// Super Puzzle Fighter II Turbo (USA)
+ { "GS-9113", CPUCACHE_EMUMODE_DATA_CB },	// Virtua Fighter Kids (Java Tea Original)
  { "T-15005G", CPUCACHE_EMUMODE_DATA_CB },	// Virtual Volleyball (Japan)
+ { "T-18601H", CPUCACHE_EMUMODE_DATA_CB },	// WipEout (USA)
+ { "T-18603G", CPUCACHE_EMUMODE_DATA_CB },	// WipEout (Japan)
+ { "T-11301H", CPUCACHE_EMUMODE_DATA_CB },	// WipEout (Europe)
+ { "GS-9061", CPUCACHE_EMUMODE_DATA_CB },	// (Hideo Nomo) World Series Baseball (Japan)
+ { "MK-81109", CPUCACHE_EMUMODE_DATA_CB },	// World Series Baseball (Europe/USA)
 
  //{ "MK-81019", CPUCACHE_EMUMODE_DATA },	// Astal (USA)
  //{ "GS-9019",  CPUCACHE_EMUMODE_DATA },	// Astal (Japan)

--- a/mednafen/ss/sh7095.inc
+++ b/mednafen/ss/sh7095.inc
@@ -2750,7 +2750,7 @@ uint32 NO_INLINE SH7095::Exception(const unsigned exnum, const unsigned vecnum)
   DBG_AddBranchTrace(this - CPU, new_PC, exnum, vecnum);
 #endif
 
- //SS_DBG(SS_DBG_WARNING | SS_DBG_SH2, "[%s] Exception %u, vecnum=%u, saved PC=0x%08x --- New PC=0x%08x\n", cpu_name, exnum, vecnum, PC, new_PC);
+ //SS_DBG(SS_DBG_WARNING | SS_DBG_SH2, "[%s] Exception %u, vecnum=%u, vbr=%08x, saved PC=0x%08x --- New PC=0x%08x, New R15=0x%08x\n", cpu_name, exnum, vecnum, VBR, PC, new_PC, R[15]);
 
  return new_PC;
 }

--- a/mednafen/ss/vdp2.cpp
+++ b/mednafen/ss/vdp2.cpp
@@ -991,24 +991,50 @@ uint32 GetRegister(const unsigned id, char* const special, const uint32 special_
 	ret = VCounter;
 	break;
 
- case GSREG_DON:
+  case GSREG_DON:
 	ret = DisplayOn;
 	break;
 
- case GSREG_BM:
+  case GSREG_BM:
 	ret = BorderMode;
 	break;
 
- case GSREG_IM:
+  case GSREG_IM:
 	ret = InterlaceMode;
 	break;
 
- case GSREG_VRES:
+  case GSREG_VRES:
 	ret = VRes;
 	break;
 
- case GSREG_HRES:
+  case GSREG_HRES:
 	ret = HRes;
+	break;
+
+  case GSREG_RAMCTL:
+	ret = RAMCTL_Raw;
+	break;
+
+  case GSREG_CYCA0:
+  case GSREG_CYCA1:
+  case GSREG_CYCB0:
+  case GSREG_CYCB1:
+	{
+	 static const char* tab[0x10] =
+	 {
+	  "NBG0 PN", "NBG1 PN", "NBG2 PN", "NBG3 PN",
+	  "NBG0 CG", "NBG1 CG", "NBG2 CG", "NBG3 CG",
+	  "ILLEGAL", "ILLEGAL", "ILLEGAL", "ILLEGAL",
+	  "NBG0 VCS", "NBG1 VCS", "CPU", "NOP"
+	 };
+	 const size_t idx = (id - GSREG_CYCA0);
+	 ret = (RawRegs[(0x10 >> 1) + (idx << 1)] << 16) | RawRegs[(0x12 >> 1) + (idx << 1)];
+
+	 if(special)
+	  trio_snprintf(special, special_len, "0: %s, 1: %s, 2: %s, 3: %s, 4: %s, 5: %s, 6: %s, 7: %s",
+		tab[(ret >> 28) & 0xF], tab[(ret >> 24) & 0xF], tab[(ret >> 20) & 0xF], tab[(ret >> 16) & 0xF],
+		tab[(ret >> 12) & 0xF], tab[(ret >>  8) & 0xF], tab[(ret >>  4) & 0xF], tab[(ret >>  0) & 0xF]);
+	}
 	break;
  }
 

--- a/mednafen/ss/vdp2.h
+++ b/mednafen/ss/vdp2.h
@@ -88,7 +88,15 @@ enum
  GSREG_BM,
  GSREG_IM,
  GSREG_VRES,
- GSREG_HRES
+ GSREG_HRES,
+
+ GSREG_RAMCTL,
+
+ GSREG_CYCA0,
+ GSREG_CYCA1 = GSREG_CYCA0 + 1,
+ GSREG_CYCB0 = GSREG_CYCA0 + 2,
+ GSREG_CYCB1 = GSREG_CYCA0 + 3
+
 };
 
 uint32 GetRegister(const unsigned id, char* const special, const uint32 special_len);

--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -1706,6 +1706,7 @@ static void T_DrawNBG23(const unsigned n, uint64* bgbuf, const unsigned w, const
  // printf("(TA_bpp == %d && n == %d && VRAM_Mode == 0x%01x && (HRes & 0x6) == 0x%01x && MDFN_de64lsb(VCPRegs[0]) == 0x%016llxULL && MDFN_de64lsb(VCPRegs[1]) == 0x%016llxULL && MDFN_de64lsb(VCPRegs[2]) == 0x%016llxULL && MDFN_de64lsb(VCPRegs[3]) == 0x%016llxULL) || \n", TA_bpp, n, VRAM_Mode, HRes & 0x6, (unsigned long long)MDFN_de64lsb(VCPRegs[0]), (unsigned long long)MDFN_de64lsb(VCPRegs[1]), (unsigned long long)MDFN_de64lsb(VCPRegs[2]), (unsigned long long)MDFN_de64lsb(VCPRegs[3]));
  if(MDFN_UNLIKELY(
   /* Akumajou Dracula X */ (TA_bpp == 4 && n == 3 && VRAM_Mode == 0x2 && (HRes & 0x6) == 0x0 && MDFN_de64lsb(VCPRegs[0]) == 0x0f0f070406060505ULL && MDFN_de64lsb(VCPRegs[1]) == 0x0f0f0f0f0f0f0f0fULL && MDFN_de64lsb(VCPRegs[2]) == 0x0f0f03000f0f0201ULL && MDFN_de64lsb(VCPRegs[3]) == 0x0f0f0f0f0f0f0f0fULL) ||
+  /* Alien Trilogy      */ (TA_bpp == 4 && n == 3 && VRAM_Mode == 0x2 && (HRes & 0x6) == 0x0 && MDFN_de64lsb(VCPRegs[0]) == 0x07050f0f0f0f0606ULL && MDFN_de64lsb(VCPRegs[1]) == 0x0f0f0f0f0f0f0f0fULL && MDFN_de64lsb(VCPRegs[2]) == 0x0f0f0f0f0f0f0f0fULL && MDFN_de64lsb(VCPRegs[3]) == 0x0f0103020f0f0f0fULL) ||
   /* Daytona USA CCE    */ (TA_bpp == 4 && n == 2 && VRAM_Mode == 0x3 && (HRes & 0x6) == 0x0 && MDFN_de64lsb(VCPRegs[0]) == 0x0f0f0f0f00000404ULL && MDFN_de64lsb(VCPRegs[1]) == 0x0f0f0f060f0f0f0fULL && MDFN_de64lsb(VCPRegs[2]) == 0x0f0f0f0f0505070fULL && MDFN_de64lsb(VCPRegs[3]) == 0x0f0f03020f010f00ULL) ||
   0))
  {


### PR DESCRIPTION
Sync with v1.21.3 of Mednafen.

Saturn fixes:

* Added kludge to fix layer offset problem in "Alien Trilogy".
* Added "WipEout" to internal database of games to use the data cache read bypass kludge with, to fix a hang that occurred when trying to exit gameplay back to the main menu.
* Added "House of the Dead (Japan)" to internal database of games to use the data cache read bypass kludge with, to fix a game crash on the gun calibration screen.
* Added "Virtua Fighter Kids (Java Tea Original)" and "World Series Baseball" to internal database of games to use the data cache read bypass kludge with, to fix gameplay glitches.
