### PR TITLE
Mednafen 1.22.0 sync

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -30,8 +30,8 @@ static INLINE bool DBG_NeedCPUHooks(void) { return false; } // <-- replaces debu
 #include <zlib.h>
 
 #define MEDNAFEN_CORE_NAME                   "Beetle Saturn"
-#define MEDNAFEN_CORE_VERSION                "v1.21.3"
-#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102103
+#define MEDNAFEN_CORE_VERSION                "v1.22.0"
+#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102200
 #define MEDNAFEN_CORE_EXTENSIONS             "cue|ccd|chd|toc|m3u"
 #define MEDNAFEN_CORE_TIMING_FPS             59.82
 #define MEDNAFEN_CORE_GEOMETRY_BASE_W        320

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -30,8 +30,8 @@ static INLINE bool DBG_NeedCPUHooks(void) { return false; } // <-- replaces debu
 #include <zlib.h>
 
 #define MEDNAFEN_CORE_NAME                   "Beetle Saturn"
-#define MEDNAFEN_CORE_VERSION                "v1.21.2"
-#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102102
+#define MEDNAFEN_CORE_VERSION                "v1.21.3"
+#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102103
 #define MEDNAFEN_CORE_EXTENSIONS             "cue|ccd|chd|toc|m3u"
 #define MEDNAFEN_CORE_TIMING_FPS             59.82
 #define MEDNAFEN_CORE_GEOMETRY_BASE_W        320

--- a/mednafen/ss/db.cpp
+++ b/mednafen/ss/db.cpp
@@ -140,6 +140,8 @@ static const struct
  { "MK-81036",	CPUCACHE_EMUMODE_DATA_CB },	// Clockwork Knight 2 (USA)
  { "T-30304G", CPUCACHE_EMUMODE_DATA_CB },	// DeJig - Lassen Art Collection (Japan)
  { "T-18504G", CPUCACHE_EMUMODE_DATA_CB },	// Father Christmas (Japan)
+ { "GS-9101",  CPUCACHE_EMUMODE_DATA_CB },	// Fighting Vipers (Japan)
+ { "MK-81041",  CPUCACHE_EMUMODE_DATA_CB },	// Fighting Vipers (Europe/USA)
  { "MK-81045", CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Europe) (and USA too?)
  { "GS-9041",	CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Japan)
  { "GS-9173", CPUCACHE_EMUMODE_DATA_CB },	// House of the Dead (Japan)

--- a/mednafen/ss/db.cpp
+++ b/mednafen/ss/db.cpp
@@ -142,6 +142,7 @@ static const struct
  { "T-18504G", CPUCACHE_EMUMODE_DATA_CB },	// Father Christmas (Japan)
  { "MK-81045", CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Europe) (and USA too?)
  { "GS-9041",	CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Japan)
+ { "GS-9173", CPUCACHE_EMUMODE_DATA_CB },	// House of the Dead (Japan)
  { "81600",	CPUCACHE_EMUMODE_DATA_CB },	// Sega Saturn Choice Cuts (USA)
  { "610680501",CPUCACHE_EMUMODE_DATA_CB },	// Segakore Sega Bible Mogitate SegaSaturn
  { "T-7001H",	CPUCACHE_EMUMODE_DATA_CB },	// Spot Goes to Hollywood (USA)
@@ -150,7 +151,13 @@ static const struct
  { "T-1206G",	CPUCACHE_EMUMODE_DATA_CB },	// Street Fighter Zero (Japan)
  { "T-1246G",	CPUCACHE_EMUMODE_DATA_CB },	// Street Fighter Zero 3 (Japan)
  { "T-1215H",	CPUCACHE_EMUMODE_DATA_CB },	// Super Puzzle Fighter II Turbo (USA)
+ { "GS-9113", CPUCACHE_EMUMODE_DATA_CB },	// Virtua Fighter Kids (Java Tea Original)
  { "T-15005G", CPUCACHE_EMUMODE_DATA_CB },	// Virtual Volleyball (Japan)
+ { "T-18601H", CPUCACHE_EMUMODE_DATA_CB },	// WipEout (USA)
+ { "T-18603G", CPUCACHE_EMUMODE_DATA_CB },	// WipEout (Japan)
+ { "T-11301H", CPUCACHE_EMUMODE_DATA_CB },	// WipEout (Europe)
+ { "GS-9061", CPUCACHE_EMUMODE_DATA_CB },	// (Hideo Nomo) World Series Baseball (Japan)
+ { "MK-81109", CPUCACHE_EMUMODE_DATA_CB },	// World Series Baseball (Europe/USA)
 
  //{ "MK-81019", CPUCACHE_EMUMODE_DATA },	// Astal (USA)
  //{ "GS-9019",  CPUCACHE_EMUMODE_DATA },	// Astal (Japan)

--- a/mednafen/ss/notes/HOST-CPU-INTENSIVE-GAMES
+++ b/mednafen/ss/notes/HOST-CPU-INTENSIVE-GAMES
@@ -1,0 +1,6 @@
+Burning Rangers
+Courier Crisis (most intensive game?)
+DecAthlete
+Grandia (FMV)
+Last Bronx
+Sky Target

--- a/mednafen/ss/scsp.h
+++ b/mednafen/ss/scsp.h
@@ -288,7 +288,6 @@ class SS_SCSP
 
   uint32 INPUTS;	// 24 bit
 
-  uint32 Product;	// 26 bit
   uint32 SFT_REG;	// 26 bit
   uint16 FRC_REG;	// 13 bit
   uint32 Y_REG;		// 24 bit, latches INPUTS
@@ -303,11 +302,16 @@ class SS_SCSP
 
   uint8 ReadPending;	// = 1 (NOFL=0), =2 (NOFL=1) at time or MRT
   uint32 ReadValue;
- } DSP;
 
+  bool MPROG_Dirty;
+ } DSP;
  //
  //
 
  uint16 RAM[262144 * 2];	// *2 for dummy so we don't have to have so many conditionals in the playback code.
+
+#ifdef MDFN_SS_SCSP_DSP_DYNAREC
+ alignas(8) uint8 DynaRecPool[65536];
+#endif
 };
 

--- a/mednafen/ss/scsp.inc
+++ b/mednafen/ss/scsp.inc
@@ -29,6 +29,12 @@
 	Proper reset/power-on state.
 
 	Mem4Mb
+
+	DSP: Handle instruction with MRT=1 and MWT=1 correctly.
+
+	DSP: Handle IWT=1 when MRT=0 and MWT=0 for the instruction a couple instructions back(NOFL influences the value...)
+
+	DSP: Test IWT=1 when MRT=0 and MWT=1 for the intruction a couple back.
 */
 
 #include "ss_endian.h"
@@ -662,6 +668,9 @@ INLINE void SS_SCSP::RW(uint32 A, T& DBV)
   //
   ne64_rwbo_be<T, IsWrite>(DSP.MPROG, A & 0x3FF, &DBV);
 
+  if(IsWrite)
+   DSP.MPROG_Dirty = true;
+
   return;
  }
 
@@ -968,6 +977,10 @@ INLINE void SS_SCSP::RunLFO(Slot* s)
 //
 //
 //
+#ifdef MDFN_SS_SCSP_DSP_DYNAREC
+ #include "scsp_dsp_dynarec.inc"
+#else
+
 static INLINE uint32 dspfloat_to_int(const uint16 inv)
 {
  const uint32 sign_xor = (int32)((inv & 0x8000) << 16) >> 1;
@@ -1098,10 +1111,7 @@ INLINE void SS_SCSP::RunDSP(void)
   }
 
   const int32 INPUTS = sign_x_to_s32(24, DSP.INPUTS);
-  const int32 TEMP = sign_x_to_s32(24, DSP.TEMP[TEMPReadAddr]);
-  const int32 X_SEL_Inputs[2] = { TEMP, INPUTS };
   const uint16 Y_SEL_Inputs[4] = { DSP.FRC_REG, DSP.COEF[CRA], (uint16)((DSP.Y_REG >> 11) & 0x1FFF), (uint16)((DSP.Y_REG >> 4) & 0x0FFF) };
-  const uint32 SGA_Inputs[2] = { (uint32)TEMP, DSP.SFT_REG };
   //
   //
   //
@@ -1112,9 +1122,7 @@ INLINE void SS_SCSP::RunDSP(void)
   //
   //
   //
-  int32 ShifterOutput;
-
-  ShifterOutput = (uint32)sign_x_to_s32(26, DSP.SFT_REG) << (SHFT0 ^ SHFT1);
+  int32 ShifterOutput = (uint32)sign_x_to_s32(26, DSP.SFT_REG) << (SHFT0 ^ SHFT1);
 
   if(!SHFT1)
   {
@@ -1124,13 +1132,6 @@ INLINE void SS_SCSP::RunDSP(void)
     ShifterOutput = 0x800000;
   }
   ShifterOutput &= 0xFFFFFF;
-
-  if(EWT)
-   DSP.EFREG[EWA] = (ShifterOutput >> 8);
-
-  if(TWT)
-   DSP.TEMP[TEMPWriteAddr] = ShifterOutput;
-
   //
   //
   if(FRCL)
@@ -1142,27 +1143,31 @@ INLINE void SS_SCSP::RunDSP(void)
   }
   //
   //
-  DSP.Product = ((int64)sign_x_to_s32(13, Y_SEL_Inputs[YSEL]) * X_SEL_Inputs[XSEL]) >> 12;
-  // if(step < 4)
-  //  printf("%u %08x %08x product=0x%08x\n", step, Y_SEL_Inputs[YSEL], X_SEL_Inputs[XSEL], DSP.Product);
+  {
+   const int32 TEMP = sign_x_to_s32(24, DSP.TEMP[TEMPReadAddr]);
+   const uint32 SGA_Inputs[2] = { (uint32)TEMP, DSP.SFT_REG };
+   const int32 X_SEL_Inputs[2] = { TEMP, INPUTS };
+   const uint32 Product = ((int64)sign_x_to_s32(13, Y_SEL_Inputs[YSEL]) * X_SEL_Inputs[XSEL]) >> 12;
+   uint32 SGAOutput;
+
+   SGAOutput = SGA_Inputs[BSEL];
+
+   if(NEGB)
+    SGAOutput = -SGAOutput;
+
+   if(ZERO)
+    SGAOutput = 0;
+
+   DSP.SFT_REG = (Product + SGAOutput) & 0x3FFFFFF;
+  }
   //
   //
-  //if((step == 3 || step == 7) && CRA)
-  // printf("Step %u: %08x %08x %08x  --- ysel=%u cra=0x%02x[0x%04x] temp=0x%08x\n", step, SGA_Inputs[BSEL], Y_SEL_Inputs[YSEL], X_SEL_Inputs[XSEL], YSEL, CRA, DSP.COEF[CRA], TEMP);
+  if(EWT)
+   DSP.EFREG[EWA] = (ShifterOutput >> 8);
 
-  uint32 SGAOutput;
+  if(TWT)
+   DSP.TEMP[TEMPWriteAddr] = ShifterOutput;
 
-  SGAOutput = SGA_Inputs[BSEL];
-
-  if(NEGB)
-   SGAOutput = -SGAOutput;
-
-  if(ZERO)
-   SGAOutput = 0;
-
-  DSP.SFT_REG = (DSP.Product + SGAOutput) & 0x3FFFFFF;
-  //
-  //
   if(IWT)
   {
    DSP.MEMS[IWA] = DSP.ReadValue;
@@ -1226,6 +1231,7 @@ INLINE void SS_SCSP::RunDSP(void)
   DSP.MDEC_CT = (0x2000 << RBL);
  DSP.MDEC_CT--;
 }
+#endif
 //
 //
 //
@@ -1566,7 +1572,6 @@ void SS_SCSP::StateAction(StateMem* sm, const unsigned load, const bool data_onl
 
   SFVAR(DSP.INPUTS),
 
-  SFVAR(DSP.Product),
   SFVAR(DSP.SFT_REG),
   SFVAR(DSP.FRC_REG),
   SFVAR(DSP.Y_REG),
@@ -1613,6 +1618,8 @@ void SS_SCSP::StateAction(StateMem* sm, const unsigned load, const bool data_onl
   RBL &= 0x3;
 
   DSP.RWAddr &= 0x7FFFF;
+  
+  DSP.MPROG_Dirty = true;
 
   for(uint32 A = 0x100000; A < 0x100400; A += 2)
   {

--- a/mednafen/ss/sh7095.inc
+++ b/mednafen/ss/sh7095.inc
@@ -3659,7 +3659,7 @@ INLINE void SH7095::Step(void)
 
 	if(GetS() && sum > 0x00007FFFFFFFFFFFULL && sum < 0xFFFF800000000000ULL)
 	{
-	 if((int64)b < 0)
+	 if((int32)(m0 ^ m1) < 0)
 	  sum = 0xFFFF800000000000ULL;
 	 else
 	  sum = 0x00007FFFFFFFFFFFULL;

--- a/mednafen/ss/sh7095.inc
+++ b/mednafen/ss/sh7095.inc
@@ -2750,7 +2750,7 @@ uint32 NO_INLINE SH7095::Exception(const unsigned exnum, const unsigned vecnum)
   DBG_AddBranchTrace(this - CPU, new_PC, exnum, vecnum);
 #endif
 
- //SS_DBG(SS_DBG_WARNING | SS_DBG_SH2, "[%s] Exception %u, vecnum=%u, saved PC=0x%08x --- New PC=0x%08x\n", cpu_name, exnum, vecnum, PC, new_PC);
+ //SS_DBG(SS_DBG_WARNING | SS_DBG_SH2, "[%s] Exception %u, vecnum=%u, vbr=%08x, saved PC=0x%08x --- New PC=0x%08x, New R15=0x%08x\n", cpu_name, exnum, vecnum, VBR, PC, new_PC, R[15]);
 
  return new_PC;
 }

--- a/mednafen/ss/smpc.cpp
+++ b/mednafen/ss/smpc.cpp
@@ -409,8 +409,14 @@ void SMPC_Init(const uint8 area_code_arg, const int32 master_clock_arg)
  vsync = false;
  lastts = 0;
 
+ for(unsigned sp = 0; sp < 2; sp++)
+  SPorts[sp] = nullptr;
+
  for(unsigned i = 0; i < 12; i++)
+ {
+  VirtualPorts[i] = nullptr;
   SMPC_SetInput(i, "none", NULL);
+ }
 
  SMPC_SetRTC(NULL, 0);
 }
@@ -479,8 +485,16 @@ void SMPC_Reset(bool powering_up)
   DirectModeEn[port] = false;
   ExLatchEn[port] = false;
   UpdateIOBus(port, SH7095_mem_timestamp);
+  //
+  if(powering_up)
+  {
+   IOPorts[port]->Power();
+   UpdateIOBus(port, SH7095_mem_timestamp);
+  }
  }
-
+ //
+ //
+ //
  ResetPending = false;
 
  PendingClockDivisor = 0;
@@ -643,10 +657,10 @@ void SMPC_EndFrame(EmulateSpecStruct* espec, const sscpu_timestamp_t timestamp)
 
 void SMPC_UpdateOutput(void)
 {
-   for(unsigned vp = 0; vp < 12; vp++)
-   {
-      VirtualPorts[vp]->UpdateOutput(VirtualPortsDPtr[vp]);
-   }
+ for(unsigned vp = 0; vp < 12; vp++)
+ {
+  VirtualPorts[vp]->UpdateOutput(VirtualPortsDPtr[vp]);
+ }
 }
 
 void SMPC_UpdateInput(const int32 time_elapsed)

--- a/mednafen/ss/vdp2.cpp
+++ b/mednafen/ss/vdp2.cpp
@@ -991,24 +991,50 @@ uint32 GetRegister(const unsigned id, char* const special, const uint32 special_
 	ret = VCounter;
 	break;
 
- case GSREG_DON:
+  case GSREG_DON:
 	ret = DisplayOn;
 	break;
 
- case GSREG_BM:
+  case GSREG_BM:
 	ret = BorderMode;
 	break;
 
- case GSREG_IM:
+  case GSREG_IM:
 	ret = InterlaceMode;
 	break;
 
- case GSREG_VRES:
+  case GSREG_VRES:
 	ret = VRes;
 	break;
 
- case GSREG_HRES:
+  case GSREG_HRES:
 	ret = HRes;
+	break;
+
+  case GSREG_RAMCTL:
+	ret = RAMCTL_Raw;
+	break;
+
+  case GSREG_CYCA0:
+  case GSREG_CYCA1:
+  case GSREG_CYCB0:
+  case GSREG_CYCB1:
+	{
+	 static const char* tab[0x10] =
+	 {
+	  "NBG0 PN", "NBG1 PN", "NBG2 PN", "NBG3 PN",
+	  "NBG0 CG", "NBG1 CG", "NBG2 CG", "NBG3 CG",
+	  "ILLEGAL", "ILLEGAL", "ILLEGAL", "ILLEGAL",
+	  "NBG0 VCS", "NBG1 VCS", "CPU", "NOP"
+	 };
+	 const size_t idx = (id - GSREG_CYCA0);
+	 ret = (RawRegs[(0x10 >> 1) + (idx << 1)] << 16) | RawRegs[(0x12 >> 1) + (idx << 1)];
+
+	 if(special)
+	  trio_snprintf(special, special_len, "0: %s, 1: %s, 2: %s, 3: %s, 4: %s, 5: %s, 6: %s, 7: %s",
+		tab[(ret >> 28) & 0xF], tab[(ret >> 24) & 0xF], tab[(ret >> 20) & 0xF], tab[(ret >> 16) & 0xF],
+		tab[(ret >> 12) & 0xF], tab[(ret >>  8) & 0xF], tab[(ret >>  4) & 0xF], tab[(ret >>  0) & 0xF]);
+	}
 	break;
  }
 

--- a/mednafen/ss/vdp2.h
+++ b/mednafen/ss/vdp2.h
@@ -88,7 +88,15 @@ enum
  GSREG_BM,
  GSREG_IM,
  GSREG_VRES,
- GSREG_HRES
+ GSREG_HRES,
+
+ GSREG_RAMCTL,
+
+ GSREG_CYCA0,
+ GSREG_CYCA1 = GSREG_CYCA0 + 1,
+ GSREG_CYCB0 = GSREG_CYCA0 + 2,
+ GSREG_CYCB1 = GSREG_CYCA0 + 3
+
 };
 
 uint32 GetRegister(const unsigned id, char* const special, const uint32 special_len);

--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -1706,6 +1706,7 @@ static void T_DrawNBG23(const unsigned n, uint64* bgbuf, const unsigned w, const
  // printf("(TA_bpp == %d && n == %d && VRAM_Mode == 0x%01x && (HRes & 0x6) == 0x%01x && MDFN_de64lsb(VCPRegs[0]) == 0x%016llxULL && MDFN_de64lsb(VCPRegs[1]) == 0x%016llxULL && MDFN_de64lsb(VCPRegs[2]) == 0x%016llxULL && MDFN_de64lsb(VCPRegs[3]) == 0x%016llxULL) || \n", TA_bpp, n, VRAM_Mode, HRes & 0x6, (unsigned long long)MDFN_de64lsb(VCPRegs[0]), (unsigned long long)MDFN_de64lsb(VCPRegs[1]), (unsigned long long)MDFN_de64lsb(VCPRegs[2]), (unsigned long long)MDFN_de64lsb(VCPRegs[3]));
  if(MDFN_UNLIKELY(
   /* Akumajou Dracula X */ (TA_bpp == 4 && n == 3 && VRAM_Mode == 0x2 && (HRes & 0x6) == 0x0 && MDFN_de64lsb(VCPRegs[0]) == 0x0f0f070406060505ULL && MDFN_de64lsb(VCPRegs[1]) == 0x0f0f0f0f0f0f0f0fULL && MDFN_de64lsb(VCPRegs[2]) == 0x0f0f03000f0f0201ULL && MDFN_de64lsb(VCPRegs[3]) == 0x0f0f0f0f0f0f0f0fULL) ||
+  /* Alien Trilogy      */ (TA_bpp == 4 && n == 3 && VRAM_Mode == 0x2 && (HRes & 0x6) == 0x0 && MDFN_de64lsb(VCPRegs[0]) == 0x07050f0f0f0f0606ULL && MDFN_de64lsb(VCPRegs[1]) == 0x0f0f0f0f0f0f0f0fULL && MDFN_de64lsb(VCPRegs[2]) == 0x0f0f0f0f0f0f0f0fULL && MDFN_de64lsb(VCPRegs[3]) == 0x0f0103020f0f0f0fULL) ||
   /* Daytona USA CCE    */ (TA_bpp == 4 && n == 2 && VRAM_Mode == 0x3 && (HRes & 0x6) == 0x0 && MDFN_de64lsb(VCPRegs[0]) == 0x0f0f0f0f00000404ULL && MDFN_de64lsb(VCPRegs[1]) == 0x0f0f0f060f0f0f0fULL && MDFN_de64lsb(VCPRegs[2]) == 0x0f0f0f0f0505070fULL && MDFN_de64lsb(VCPRegs[3]) == 0x0f0f03020f010f00ULL) ||
   0))
  {


### PR DESCRIPTION
Sync with Mednafen 1.22.0

* Added "Fighting Vipers" to the internal database of games to use the data cache read bypass kludge with, to fix the problem of the computer-controlled opponent sometimes losing the will to not be a statue.
* Emulated input devices' internal states were not being reset on virtual power toggle; fixed.
* Reorganized SCSP DSP emulation code to make the lifetime of variables clearer, for a possible x86_64 dynarec in the future.
* Fixed an emulation inaccuracy with the handling of the SH-2 "mac.l" instruction when saturation is enabled, per tests on a SS.

I haven't added the changes to the cart emulation relating to debug/testing code in Mednafen.
