### PR TITLE
Mednafen 1.22.1 sync

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -30,8 +30,8 @@ static INLINE bool DBG_NeedCPUHooks(void) { return false; } // <-- replaces debu
 #include <zlib.h>
 
 #define MEDNAFEN_CORE_NAME                   "Beetle Saturn"
-#define MEDNAFEN_CORE_VERSION                "v1.22.0"
-#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102200
+#define MEDNAFEN_CORE_VERSION                "v1.22.1"
+#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102201
 #define MEDNAFEN_CORE_EXTENSIONS             "cue|ccd|chd|toc|m3u"
 #define MEDNAFEN_CORE_TIMING_FPS             59.82
 #define MEDNAFEN_CORE_GEOMETRY_BASE_W        320

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -30,8 +30,8 @@ static INLINE bool DBG_NeedCPUHooks(void) { return false; } // <-- replaces debu
 #include <zlib.h>
 
 #define MEDNAFEN_CORE_NAME                   "Beetle Saturn"
-#define MEDNAFEN_CORE_VERSION                "v1.21.3"
-#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102103
+#define MEDNAFEN_CORE_VERSION                "v1.22.0"
+#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102200
 #define MEDNAFEN_CORE_EXTENSIONS             "cue|ccd|chd|toc|m3u"
 #define MEDNAFEN_CORE_TIMING_FPS             59.82
 #define MEDNAFEN_CORE_GEOMETRY_BASE_W        320

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -30,8 +30,8 @@ static INLINE bool DBG_NeedCPUHooks(void) { return false; } // <-- replaces debu
 #include <zlib.h>
 
 #define MEDNAFEN_CORE_NAME                   "Beetle Saturn"
-#define MEDNAFEN_CORE_VERSION                "v1.21.2"
-#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102102
+#define MEDNAFEN_CORE_VERSION                "v1.21.3"
+#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102103
 #define MEDNAFEN_CORE_EXTENSIONS             "cue|ccd|chd|toc|m3u"
 #define MEDNAFEN_CORE_TIMING_FPS             59.82
 #define MEDNAFEN_CORE_GEOMETRY_BASE_W        320

--- a/mednafen/ss/cdb.h
+++ b/mednafen/ss/cdb.h
@@ -46,5 +46,24 @@ void CDB_SetClockRatio(uint32 ratio);
 void CDB_ResetCD(void);
 void CDB_SetCDActive(bool active);
 
+enum
+{
+ CDB_GSREG_HIRQ = 0,
+ CDB_GSREG_HIRQ_MASK,
+
+ CDB_GSREG_CDATA0,
+ CDB_GSREG_CDATA1,
+ CDB_GSREG_CDATA2,
+ CDB_GSREG_CDATA3,
+
+ CDB_GSREG_RESULT0,
+ CDB_GSREG_RESULT1,
+ CDB_GSREG_RESULT2,
+ CDB_GSREG_RESULT3
+};
+
+uint32 CDB_GetRegister(const unsigned id, char* const special, const uint32 special_len) MDFN_COLD;
+void CDB_SetRegister(const unsigned id, const uint32 value) MDFN_COLD;
+
 
 #endif

--- a/mednafen/ss/db.cpp
+++ b/mednafen/ss/db.cpp
@@ -140,6 +140,8 @@ static const struct
  { "MK-81036",	CPUCACHE_EMUMODE_DATA_CB },	// Clockwork Knight 2 (USA)
  { "T-30304G", CPUCACHE_EMUMODE_DATA_CB },	// DeJig - Lassen Art Collection (Japan)
  { "T-18504G", CPUCACHE_EMUMODE_DATA_CB },	// Father Christmas (Japan)
+ { "GS-9101",  CPUCACHE_EMUMODE_DATA_CB },	// Fighting Vipers (Japan)
+ { "MK-81041",  CPUCACHE_EMUMODE_DATA_CB },	// Fighting Vipers (Europe/USA)
  { "MK-81045", CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Europe) (and USA too?)
  { "GS-9041",	CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Japan)
  { "GS-9173", CPUCACHE_EMUMODE_DATA_CB },	// House of the Dead (Japan)

--- a/mednafen/ss/db.cpp
+++ b/mednafen/ss/db.cpp
@@ -84,6 +84,10 @@ static const struct
  //
  //
  //
+ { "T-16804G", CART_BACKUP_MEM },// Dezaemon 2
+ //
+ //
+ //
  { "MK-81088", CART_KOF95 },	// The King of Fighters '95 (Europe)
  { "T-3101G", CART_KOF95 },	// The King of Fighters '95
  { "T-13308G", CART_ULTRAMAN },// Ultraman: Hikari no Kyojin Densetsu
@@ -126,6 +130,7 @@ static const struct
  //
  //
  { nullptr, CART_CS1RAM_16M, { 0x4a, 0xf9, 0xff, 0x30, 0xea, 0x54, 0xfe, 0x3a, 0x79, 0xa7, 0x68, 0x69, 0xae, 0xde, 0x55, 0xbb } },	// Heart of Darkness (Prototype)
+ { nullptr, CART_CS1RAM_16M, { 0xf1, 0x71, 0xc3, 0xe4, 0x69, 0xd5, 0x99, 0x93, 0x94, 0x09, 0x05, 0xfc, 0x29, 0xd3, 0x8a, 0x59 } },	// Heart of Darkness (Prototype)
 };
 
 static const struct
@@ -145,6 +150,7 @@ static const struct
  { "MK-81045", CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Europe) (and USA too?)
  { "GS-9041",	CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Japan)
  { "GS-9173", CPUCACHE_EMUMODE_DATA_CB },	// House of the Dead (Japan)
+ { "GS-9055", CPUCACHE_EMUMODE_DATA_CB },	// Linkle Liver Story
  { "81600",	CPUCACHE_EMUMODE_DATA_CB },	// Sega Saturn Choice Cuts (USA)
  { "610680501",CPUCACHE_EMUMODE_DATA_CB },	// Segakore Sega Bible Mogitate SegaSaturn
  { "T-7001H",	CPUCACHE_EMUMODE_DATA_CB },	// Spot Goes to Hollywood (USA)
@@ -219,3 +225,4 @@ void DB_Lookup(const char* path, const char* sgid, const uint8* fd_id, unsigned*
  }
 #endif
 }
+

--- a/mednafen/ss/db.cpp
+++ b/mednafen/ss/db.cpp
@@ -142,6 +142,7 @@ static const struct
  { "T-18504G", CPUCACHE_EMUMODE_DATA_CB },	// Father Christmas (Japan)
  { "MK-81045", CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Europe) (and USA too?)
  { "GS-9041",	CPUCACHE_EMUMODE_DATA_CB },	// Golden Axe - The Duel (Japan)
+ { "GS-9173", CPUCACHE_EMUMODE_DATA_CB },	// House of the Dead (Japan)
  { "81600",	CPUCACHE_EMUMODE_DATA_CB },	// Sega Saturn Choice Cuts (USA)
  { "610680501",CPUCACHE_EMUMODE_DATA_CB },	// Segakore Sega Bible Mogitate SegaSaturn
  { "T-7001H",	CPUCACHE_EMUMODE_DATA_CB },	// Spot Goes to Hollywood (USA)
@@ -150,7 +151,13 @@ static const struct
  { "T-1206G",	CPUCACHE_EMUMODE_DATA_CB },	// Street Fighter Zero (Japan)
  { "T-1246G",	CPUCACHE_EMUMODE_DATA_CB },	// Street Fighter Zero 3 (Japan)
  { "T-1215H",	CPUCACHE_EMUMODE_DATA_CB },	// Super Puzzle Fighter II Turbo (USA)
+ { "GS-9113", CPUCACHE_EMUMODE_DATA_CB },	// Virtua Fighter Kids (Java Tea Original)
  { "T-15005G", CPUCACHE_EMUMODE_DATA_CB },	// Virtual Volleyball (Japan)
+ { "T-18601H", CPUCACHE_EMUMODE_DATA_CB },	// WipEout (USA)
+ { "T-18603G", CPUCACHE_EMUMODE_DATA_CB },	// WipEout (Japan)
+ { "T-11301H", CPUCACHE_EMUMODE_DATA_CB },	// WipEout (Europe)
+ { "GS-9061", CPUCACHE_EMUMODE_DATA_CB },	// (Hideo Nomo) World Series Baseball (Japan)
+ { "MK-81109", CPUCACHE_EMUMODE_DATA_CB },	// World Series Baseball (Europe/USA)
 
  //{ "MK-81019", CPUCACHE_EMUMODE_DATA },	// Astal (USA)
  //{ "GS-9019",  CPUCACHE_EMUMODE_DATA },	// Astal (Japan)

--- a/mednafen/ss/notes/HOST-CPU-INTENSIVE-GAMES
+++ b/mednafen/ss/notes/HOST-CPU-INTENSIVE-GAMES
@@ -1,0 +1,6 @@
+Burning Rangers
+Courier Crisis (most intensive game?)
+DecAthlete
+Grandia (FMV)
+Last Bronx
+Sky Target

--- a/mednafen/ss/scsp.h
+++ b/mednafen/ss/scsp.h
@@ -288,7 +288,6 @@ class SS_SCSP
 
   uint32 INPUTS;	// 24 bit
 
-  uint32 Product;	// 26 bit
   uint32 SFT_REG;	// 26 bit
   uint16 FRC_REG;	// 13 bit
   uint32 Y_REG;		// 24 bit, latches INPUTS
@@ -303,11 +302,16 @@ class SS_SCSP
 
   uint8 ReadPending;	// = 1 (NOFL=0), =2 (NOFL=1) at time or MRT
   uint32 ReadValue;
- } DSP;
 
+  bool MPROG_Dirty;
+ } DSP;
  //
  //
 
  uint16 RAM[262144 * 2];	// *2 for dummy so we don't have to have so many conditionals in the playback code.
+
+#ifdef MDFN_SS_SCSP_DSP_DYNAREC
+ alignas(8) uint8 DynaRecPool[65536];
+#endif
 };
 

--- a/mednafen/ss/scsp.inc
+++ b/mednafen/ss/scsp.inc
@@ -29,6 +29,12 @@
 	Proper reset/power-on state.
 
 	Mem4Mb
+
+	DSP: Handle instruction with MRT=1 and MWT=1 correctly.
+
+	DSP: Handle IWT=1 when MRT=0 and MWT=0 for the instruction a couple instructions back(NOFL influences the value...)
+
+	DSP: Test IWT=1 when MRT=0 and MWT=1 for the intruction a couple back.
 */
 
 #include "ss_endian.h"
@@ -662,6 +668,9 @@ INLINE void SS_SCSP::RW(uint32 A, T& DBV)
   //
   ne64_rwbo_be<T, IsWrite>(DSP.MPROG, A & 0x3FF, &DBV);
 
+  if(IsWrite)
+   DSP.MPROG_Dirty = true;
+
   return;
  }
 
@@ -968,6 +977,10 @@ INLINE void SS_SCSP::RunLFO(Slot* s)
 //
 //
 //
+#ifdef MDFN_SS_SCSP_DSP_DYNAREC
+ #include "scsp_dsp_dynarec.inc"
+#else
+
 static INLINE uint32 dspfloat_to_int(const uint16 inv)
 {
  const uint32 sign_xor = (int32)((inv & 0x8000) << 16) >> 1;
@@ -1098,10 +1111,7 @@ INLINE void SS_SCSP::RunDSP(void)
   }
 
   const int32 INPUTS = sign_x_to_s32(24, DSP.INPUTS);
-  const int32 TEMP = sign_x_to_s32(24, DSP.TEMP[TEMPReadAddr]);
-  const int32 X_SEL_Inputs[2] = { TEMP, INPUTS };
   const uint16 Y_SEL_Inputs[4] = { DSP.FRC_REG, DSP.COEF[CRA], (uint16)((DSP.Y_REG >> 11) & 0x1FFF), (uint16)((DSP.Y_REG >> 4) & 0x0FFF) };
-  const uint32 SGA_Inputs[2] = { (uint32)TEMP, DSP.SFT_REG };
   //
   //
   //
@@ -1112,9 +1122,7 @@ INLINE void SS_SCSP::RunDSP(void)
   //
   //
   //
-  int32 ShifterOutput;
-
-  ShifterOutput = (uint32)sign_x_to_s32(26, DSP.SFT_REG) << (SHFT0 ^ SHFT1);
+  int32 ShifterOutput = (uint32)sign_x_to_s32(26, DSP.SFT_REG) << (SHFT0 ^ SHFT1);
 
   if(!SHFT1)
   {
@@ -1124,13 +1132,6 @@ INLINE void SS_SCSP::RunDSP(void)
     ShifterOutput = 0x800000;
   }
   ShifterOutput &= 0xFFFFFF;
-
-  if(EWT)
-   DSP.EFREG[EWA] = (ShifterOutput >> 8);
-
-  if(TWT)
-   DSP.TEMP[TEMPWriteAddr] = ShifterOutput;
-
   //
   //
   if(FRCL)
@@ -1142,27 +1143,31 @@ INLINE void SS_SCSP::RunDSP(void)
   }
   //
   //
-  DSP.Product = ((int64)sign_x_to_s32(13, Y_SEL_Inputs[YSEL]) * X_SEL_Inputs[XSEL]) >> 12;
-  // if(step < 4)
-  //  printf("%u %08x %08x product=0x%08x\n", step, Y_SEL_Inputs[YSEL], X_SEL_Inputs[XSEL], DSP.Product);
+  {
+   const int32 TEMP = sign_x_to_s32(24, DSP.TEMP[TEMPReadAddr]);
+   const uint32 SGA_Inputs[2] = { (uint32)TEMP, DSP.SFT_REG };
+   const int32 X_SEL_Inputs[2] = { TEMP, INPUTS };
+   const uint32 Product = ((int64)sign_x_to_s32(13, Y_SEL_Inputs[YSEL]) * X_SEL_Inputs[XSEL]) >> 12;
+   uint32 SGAOutput;
+
+   SGAOutput = SGA_Inputs[BSEL];
+
+   if(NEGB)
+    SGAOutput = -SGAOutput;
+
+   if(ZERO)
+    SGAOutput = 0;
+
+   DSP.SFT_REG = (Product + SGAOutput) & 0x3FFFFFF;
+  }
   //
   //
-  //if((step == 3 || step == 7) && CRA)
-  // printf("Step %u: %08x %08x %08x  --- ysel=%u cra=0x%02x[0x%04x] temp=0x%08x\n", step, SGA_Inputs[BSEL], Y_SEL_Inputs[YSEL], X_SEL_Inputs[XSEL], YSEL, CRA, DSP.COEF[CRA], TEMP);
+  if(EWT)
+   DSP.EFREG[EWA] = (ShifterOutput >> 8);
 
-  uint32 SGAOutput;
+  if(TWT)
+   DSP.TEMP[TEMPWriteAddr] = ShifterOutput;
 
-  SGAOutput = SGA_Inputs[BSEL];
-
-  if(NEGB)
-   SGAOutput = -SGAOutput;
-
-  if(ZERO)
-   SGAOutput = 0;
-
-  DSP.SFT_REG = (DSP.Product + SGAOutput) & 0x3FFFFFF;
-  //
-  //
   if(IWT)
   {
    DSP.MEMS[IWA] = DSP.ReadValue;
@@ -1226,6 +1231,7 @@ INLINE void SS_SCSP::RunDSP(void)
   DSP.MDEC_CT = (0x2000 << RBL);
  DSP.MDEC_CT--;
 }
+#endif
 //
 //
 //
@@ -1566,7 +1572,6 @@ void SS_SCSP::StateAction(StateMem* sm, const unsigned load, const bool data_onl
 
   SFVAR(DSP.INPUTS),
 
-  SFVAR(DSP.Product),
   SFVAR(DSP.SFT_REG),
   SFVAR(DSP.FRC_REG),
   SFVAR(DSP.Y_REG),
@@ -1613,6 +1618,8 @@ void SS_SCSP::StateAction(StateMem* sm, const unsigned load, const bool data_onl
   RBL &= 0x3;
 
   DSP.RWAddr &= 0x7FFFF;
+  
+  DSP.MPROG_Dirty = true;
 
   for(uint32 A = 0x100000; A < 0x100400; A += 2)
   {

--- a/mednafen/ss/sh7095.inc
+++ b/mednafen/ss/sh7095.inc
@@ -3659,7 +3659,7 @@ INLINE void SH7095::Step(void)
 
 	if(GetS() && sum > 0x00007FFFFFFFFFFFULL && sum < 0xFFFF800000000000ULL)
 	{
-	 if((int64)b < 0)
+	 if((int32)(m0 ^ m1) < 0)
 	  sum = 0xFFFF800000000000ULL;
 	 else
 	  sum = 0x00007FFFFFFFFFFFULL;

--- a/mednafen/ss/sh7095.inc
+++ b/mednafen/ss/sh7095.inc
@@ -2,7 +2,7 @@
 /* Mednafen Sega Saturn Emulation Module                                      */
 /******************************************************************************/
 /* sh7095.inc - Hitachi SH7095 Emulation
-**  Copyright (C) 2015-2017 Mednafen Team
+**  Copyright (C) 2015-2019 Mednafen Team
 **
 ** This program is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU General Public License
@@ -1961,6 +1961,28 @@ INLINE T SH7095::MemReadRT(uint32 A)
  else
   timestamp = std::max<sscpu_timestamp_t>(MA_until, timestamp);
 
+#ifdef MDFN_SS_DEV_BUILD
+  if((A & 0xC7FFFFFF) >= 0x06000200 && (A & 0xC7FFFFFF) <= 0x060003FF)
+  {
+   const uint32 pcm = PC & 0x07FFFFFF;
+   bool match = (pcm >= 0x100000) && (pcm < 0x06000600 || pcm >= 0x06000A00);
+
+   if(match && !BWMIgnoreAddr[0][A & 0x1FF])
+   {
+    SS_DBG(SS_DBG_BIOS, "[%s] Read from BIOS area of RAM 0x%08x; PC=0x%08x\n", cpu_name, A, PC);
+   }
+  }
+
+  if((A & 0xC7FFFFFF) >= 0x00000200/*0x00000004*//*0x00000000*/ && (A & 0xC7FFFFFF) <= 0x000FFFFF)
+  {
+   const uint32 pcm = PC & 0x07FFFFFF;
+   bool match = (pcm >= 0x100000) && (pcm < 0x06000600 || pcm >= 0x06000A00);
+
+   if(match)
+    SS_DBG(SS_DBG_BIOS, "[%s] Read from BIOS ROM 0x%06x; PC=0x%08x\n", cpu_name, A, PC);
+  }
+#endif
+
  //
  // WARNING: Template arguments CacheEnabled and TwoWayMode are only valid for region==0.  In addition, TwoWayMode is only valid for CacheEnabled==true.
  //
@@ -2130,6 +2152,19 @@ INLINE void SH7095::MemWriteRT(uint32 A, T V)
  }
 
  MA_until = std::max<sscpu_timestamp_t>(MA_until, timestamp + 1);
+
+#ifdef MDFN_SS_DEV_BUILD
+  if((A & 0xC7FFFFFF) >= 0x06000200 && (A & 0xC7FFFFFF) <= 0x060003FF)
+  {
+   const uint32 pcm = PC & 0x07FFFFFF;
+   bool match = (pcm >= 0x100000) && (pcm < 0x06000600 || pcm >= 0x06000800);
+
+   if(match && !BWMIgnoreAddr[1][A & 0x1FF])
+   {
+    SS_DBG(SS_DBG_BIOS, "[%s] Write to BIOS area of RAM 0x%08x; PC=0x%08x\n", cpu_name, A, PC);
+   }
+  }
+#endif
 
  //
  // WARNING: Template argument CacheEnabled is only valid for region==0.

--- a/mednafen/ss/sh7095.inc
+++ b/mednafen/ss/sh7095.inc
@@ -2750,7 +2750,7 @@ uint32 NO_INLINE SH7095::Exception(const unsigned exnum, const unsigned vecnum)
   DBG_AddBranchTrace(this - CPU, new_PC, exnum, vecnum);
 #endif
 
- //SS_DBG(SS_DBG_WARNING | SS_DBG_SH2, "[%s] Exception %u, vecnum=%u, saved PC=0x%08x --- New PC=0x%08x\n", cpu_name, exnum, vecnum, PC, new_PC);
+ //SS_DBG(SS_DBG_WARNING | SS_DBG_SH2, "[%s] Exception %u, vecnum=%u, vbr=%08x, saved PC=0x%08x --- New PC=0x%08x, New R15=0x%08x\n", cpu_name, exnum, vecnum, VBR, PC, new_PC, R[15]);
 
  return new_PC;
 }

--- a/mednafen/ss/smpc.cpp
+++ b/mednafen/ss/smpc.cpp
@@ -409,8 +409,14 @@ void SMPC_Init(const uint8 area_code_arg, const int32 master_clock_arg)
  vsync = false;
  lastts = 0;
 
+ for(unsigned sp = 0; sp < 2; sp++)
+  SPorts[sp] = nullptr;
+
  for(unsigned i = 0; i < 12; i++)
+ {
+  VirtualPorts[i] = nullptr;
   SMPC_SetInput(i, "none", NULL);
+ }
 
  SMPC_SetRTC(NULL, 0);
 }
@@ -479,8 +485,16 @@ void SMPC_Reset(bool powering_up)
   DirectModeEn[port] = false;
   ExLatchEn[port] = false;
   UpdateIOBus(port, SH7095_mem_timestamp);
+  //
+  if(powering_up)
+  {
+   IOPorts[port]->Power();
+   UpdateIOBus(port, SH7095_mem_timestamp);
+  }
  }
-
+ //
+ //
+ //
  ResetPending = false;
 
  PendingClockDivisor = 0;
@@ -643,10 +657,10 @@ void SMPC_EndFrame(EmulateSpecStruct* espec, const sscpu_timestamp_t timestamp)
 
 void SMPC_UpdateOutput(void)
 {
-   for(unsigned vp = 0; vp < 12; vp++)
-   {
-      VirtualPorts[vp]->UpdateOutput(VirtualPortsDPtr[vp]);
-   }
+ for(unsigned vp = 0; vp < 12; vp++)
+ {
+  VirtualPorts[vp]->UpdateOutput(VirtualPortsDPtr[vp]);
+ }
 }
 
 void SMPC_UpdateInput(const int32 time_elapsed)

--- a/mednafen/ss/ss.h
+++ b/mednafen/ss/ss.h
@@ -46,12 +46,15 @@
   SS_DBG_SMPC 	   = (1U << 12),
   SS_DBG_SMPC_REGW = (1U << 13),
 
+  SS_DBG_BIOS	   = (1U << 15),
+
   SS_DBG_CDB  	   = (1U << 16),
   SS_DBG_CDB_REGW  = (1U << 17),
 
   SS_DBG_VDP1 	   = (1U << 20),
   SS_DBG_VDP1_REGW = (1U << 21),
   SS_DBG_VDP1_VRAMW= (1U << 22),
+  SS_DBG_VDP1_FBW  = (1U << 23),
 
   SS_DBG_VDP2 	   = (1U << 24),
   SS_DBG_VDP2_REGW = (1U << 25),

--- a/mednafen/ss/vdp1.cpp
+++ b/mednafen/ss/vdp1.cpp
@@ -972,4 +972,51 @@ void MakeDump(const std::string& path)
 #endif
 }
 
+uint32 GetRegister(const unsigned id, char* const special, const uint32 special_len)
+{
+ uint32 ret = 0xDEADBEEF;
+
+ switch(id)
+ {
+  case GSREG_SYSCLIPX:
+	ret = SysClipX;
+	break;
+
+  case GSREG_SYSCLIPY:
+	ret = SysClipY;
+	break;
+
+  case GSREG_USERCLIPX0:
+	ret = UserClipX0;
+	break;
+
+  case GSREG_USERCLIPY0:
+	ret = UserClipY0;
+	break;
+
+  case GSREG_USERCLIPX1:
+	ret = UserClipX1;
+	break;
+
+  case GSREG_USERCLIPY1:
+	ret = UserClipY1;
+	break;
+
+  case GSREG_LOCALX:
+	ret = LocalX;
+	break;
+
+  case GSREG_LOCALY:
+	ret = LocalY;
+ 	break;
+ }
+
+ return ret;
+}
+
+void SetRegister(const unsigned id, const uint32 value)
+{
+ // TODO
+}
+
 }

--- a/mednafen/ss/vdp1.h
+++ b/mednafen/ss/vdp1.h
@@ -81,6 +81,20 @@ INLINE void PokeFB(const bool which, const uint32 addr, const uint8 val)
 void MakeDump(const std::string& path) MDFN_COLD;
 #endif
 
+enum
+{
+ GSREG_SYSCLIPX = 0,
+ GSREG_SYSCLIPY,
+ GSREG_USERCLIPX0,
+ GSREG_USERCLIPY0,
+ GSREG_USERCLIPX1,
+ GSREG_USERCLIPY1,
+ GSREG_LOCALX,
+ GSREG_LOCALY
+};
+uint32 GetRegister(const unsigned id, char* const special, const uint32 special_len) MDFN_COLD;
+void SetRegister(const unsigned id, const uint32 value) MDFN_COLD;
+
 }
 
 

--- a/mednafen/ss/vdp2.cpp
+++ b/mednafen/ss/vdp2.cpp
@@ -1036,6 +1036,119 @@ uint32 GetRegister(const unsigned id, char* const special, const uint32 special_
 		tab[(ret >> 12) & 0xF], tab[(ret >>  8) & 0xF], tab[(ret >>  4) & 0xF], tab[(ret >>  0) & 0xF]);
 	}
 	break;
+
+  case GSREG_BGON:
+	ret = BGON;
+	break;
+
+  case GSREG_MZCTL:
+	ret = RawRegs[0x22 >> 1] & 0xFF1F;
+	break;
+
+  case GSREG_SFSEL:
+	ret = RawRegs[0x24 >> 1] & 0x001F;
+	break;
+
+  case GSREG_SFCODE:
+	ret = RawRegs[0x26 >> 1];
+	break;
+
+  case GSREG_CHCTLA:
+	ret = RawRegs[0x28 >> 1] & 0x3F7F;
+	break;
+
+  case GSREG_CHCTLB:
+	ret = RawRegs[0x2A >> 1] & 0x7733;
+	break;
+  //
+  //
+  case GSREG_SCXIN0:
+	ret = RawRegs[0x70 >> 1] & 0x07FF;
+	break;
+
+  case GSREG_SCXDN0:
+	ret = RawRegs[0x72 >> 1] & 0xFF00;
+	break;
+
+  case GSREG_SCYIN0:
+	ret = RawRegs[0x74 >> 1] & 0x07FF;
+	break;
+
+  case GSREG_SCYDN0:
+	ret = RawRegs[0x76 >> 1] & 0xFF00;
+	break;
+
+  case GSREG_ZMXIN0:
+	ret = RawRegs[0x78 >> 1] & 0x0007;
+	break;
+
+  case GSREG_ZMXDN0:
+	ret = RawRegs[0x7A >> 1] & 0xFF00;
+	break;
+
+  case GSREG_ZMYIN0:
+	ret = RawRegs[0x7C >> 1] & 0x0007;
+	break;
+
+  case GSREG_ZMYDN0:
+	ret = RawRegs[0x7E >> 1] & 0xFF00;
+	break;
+
+  case GSREG_SCXIN1:
+	ret = RawRegs[0x80 >> 1] & 0x07FF;
+	break;
+
+  case GSREG_SCXDN1:
+	ret = RawRegs[0x82 >> 1] & 0xFF00;
+	break;
+
+  case GSREG_SCYIN1:
+	ret = RawRegs[0x84 >> 1] & 0x07FF;
+	break;
+
+  case GSREG_SCYDN1:
+	ret = RawRegs[0x86 >> 1] & 0xFF00;
+	break;
+
+  case GSREG_ZMXIN1:
+	ret = RawRegs[0x88 >> 1] & 0x0007;
+	break;
+
+  case GSREG_ZMXDN1:
+	ret = RawRegs[0x8A >> 1] & 0xFF00;
+	break;
+
+  case GSREG_ZMYIN1:
+	ret = RawRegs[0x8C >> 1] & 0x0007;
+	break;
+
+  case GSREG_ZMYDN1:
+	ret = RawRegs[0x8E >> 1] & 0xFF00;
+	break;
+
+  case GSREG_SCXN2:
+	ret = RawRegs[0x90 >> 1] & 0x07FF;
+	break;
+
+  case GSREG_SCYN2:
+	ret = RawRegs[0x92 >> 1] & 0x07FF;
+	break;
+
+  case GSREG_SCXN3:
+	ret = RawRegs[0x94 >> 1] & 0x07FF;
+	break;
+
+  case GSREG_SCYN3:
+	ret = RawRegs[0x96 >> 1] & 0x07FF;
+	break;
+
+  case GSREG_ZMCTL:
+	ret = RawRegs[0x98 >> 1] & 0x0303;
+	break;
+
+  case GSREG_SCRCTL:
+	ret = RawRegs[0x9A >> 1] & 0x3F3F;
+	break;
  }
 
  return ret;
@@ -1043,18 +1156,143 @@ uint32 GetRegister(const unsigned id, char* const special, const uint32 special_
 
 void SetRegister(const unsigned id, const uint32 value)
 {
+ int rr = -1;
 
+ switch(id)
+ {
+  case GSREG_BGON:
+	BGON = value & 0x1F3F;
+	rr = 0x20 >> 1;
+	break;
+
+  case GSREG_MZCTL:
+	rr = 0x22 >> 1;
+	break;
+
+  case GSREG_SFSEL:
+	rr = 0x24 >> 1;
+	break;
+
+  case GSREG_SFCODE:
+	rr = 0x26 >> 1;
+	break;
+
+  case GSREG_CHCTLA:
+	rr = 0x28 >> 1;
+	break;
+
+  case GSREG_CHCTLB:
+	rr = 0x2A >> 1;
+	break;
+  //
+  //
+  case GSREG_SCXIN0:
+	rr = 0x70 >> 1;
+	break;
+
+  case GSREG_SCXDN0:
+	rr = 0x72 >> 1;
+	break;
+
+  case GSREG_SCYIN0:
+	rr = 0x74 >> 1;
+	break;
+
+  case GSREG_SCYDN0:
+	rr = 0x76 >> 1;
+	break;
+
+  case GSREG_ZMXIN0:
+	rr = 0x78 >> 1;
+	break;
+
+  case GSREG_ZMXDN0:
+	rr = 0x7A >> 1;
+	break;
+
+  case GSREG_ZMYIN0:
+	rr = 0x7C >> 1;
+	break;
+
+  case GSREG_ZMYDN0:
+	rr = 0x7E >> 1;
+	break;
+
+  case GSREG_SCXIN1:
+	rr = 0x80 >> 1;
+	break;
+
+  case GSREG_SCXDN1:
+	rr = 0x82 >> 1;
+	break;
+
+  case GSREG_SCYIN1:
+	rr = 0x84 >> 1;
+	break;
+
+  case GSREG_SCYDN1:
+	rr = 0x86 >> 1;
+	break;
+
+  case GSREG_ZMXIN1:
+	rr = 0x88 >> 1;
+	break;
+
+  case GSREG_ZMXDN1:
+	rr = 0x8A >> 1;
+	break;
+
+  case GSREG_ZMYIN1:
+	rr = 0x8C >> 1;
+	break;
+
+  case GSREG_ZMYDN1:
+	rr = 0x8E >> 1;
+	break;
+
+  case GSREG_SCXN2:
+	rr = 0x90 >> 1;
+	break;
+
+  case GSREG_SCYN2:
+	rr = 0x92 >> 1;
+	break;
+
+  case GSREG_SCXN3:
+	rr = 0x94 >> 1;
+	break;
+
+  case GSREG_SCYN3:
+	rr = 0x96 >> 1;
+	break;
+
+  case GSREG_ZMCTL:
+	rr = 0x98 >> 1;
+	break;
+
+  case GSREG_SCRCTL:
+	rr = 0x9A >> 1;
+	break;
+ }
+
+ if(rr >= 0)
+ {
+  RawRegs[rr] = (uint16)value;
+  VDP2REND_Write16_DB(0x180000 + (rr << 1), RawRegs[rr]);
+ }
 }
 
-uint8 PeekVRAM(const uint32 addr)
+uint8 PeekVRAM(uint32 addr)
 {
  return ne16_rbo_be<uint8>(VRAM, addr & 0x7FFFF);
 }
 
-void PokeVRAM(const uint32 addr, const uint8 val)
+void PokeVRAM(uint32 addr, const uint8 val)
 {
- ne16_wbo_be<uint8>(VRAM, addr & 0x7FFFF, val);
- //VDP2REND_Write8_DB(addr, val << (((A & 1) ^ 1) << 3));
+ addr &= 0x7FFFF;
+
+ ne16_wbo_be<uint8>(VRAM, addr, val);
+ VDP2REND_Write16_DB(addr & ~1, ne16_rbo_be<uint16>(VRAM, addr & ~1));
 }
 
 void SetLayerEnableMask(uint64 mask)

--- a/mednafen/ss/vdp2.cpp
+++ b/mednafen/ss/vdp2.cpp
@@ -991,24 +991,50 @@ uint32 GetRegister(const unsigned id, char* const special, const uint32 special_
 	ret = VCounter;
 	break;
 
- case GSREG_DON:
+  case GSREG_DON:
 	ret = DisplayOn;
 	break;
 
- case GSREG_BM:
+  case GSREG_BM:
 	ret = BorderMode;
 	break;
 
- case GSREG_IM:
+  case GSREG_IM:
 	ret = InterlaceMode;
 	break;
 
- case GSREG_VRES:
+  case GSREG_VRES:
 	ret = VRes;
 	break;
 
- case GSREG_HRES:
+  case GSREG_HRES:
 	ret = HRes;
+	break;
+
+  case GSREG_RAMCTL:
+	ret = RAMCTL_Raw;
+	break;
+
+  case GSREG_CYCA0:
+  case GSREG_CYCA1:
+  case GSREG_CYCB0:
+  case GSREG_CYCB1:
+	{
+	 static const char* tab[0x10] =
+	 {
+	  "NBG0 PN", "NBG1 PN", "NBG2 PN", "NBG3 PN",
+	  "NBG0 CG", "NBG1 CG", "NBG2 CG", "NBG3 CG",
+	  "ILLEGAL", "ILLEGAL", "ILLEGAL", "ILLEGAL",
+	  "NBG0 VCS", "NBG1 VCS", "CPU", "NOP"
+	 };
+	 const size_t idx = (id - GSREG_CYCA0);
+	 ret = (RawRegs[(0x10 >> 1) + (idx << 1)] << 16) | RawRegs[(0x12 >> 1) + (idx << 1)];
+
+	 if(special)
+	  trio_snprintf(special, special_len, "0: %s, 1: %s, 2: %s, 3: %s, 4: %s, 5: %s, 6: %s, 7: %s",
+		tab[(ret >> 28) & 0xF], tab[(ret >> 24) & 0xF], tab[(ret >> 20) & 0xF], tab[(ret >> 16) & 0xF],
+		tab[(ret >> 12) & 0xF], tab[(ret >>  8) & 0xF], tab[(ret >>  4) & 0xF], tab[(ret >>  0) & 0xF]);
+	}
 	break;
  }
 

--- a/mednafen/ss/vdp2.h
+++ b/mednafen/ss/vdp2.h
@@ -2,7 +2,7 @@
 /* Mednafen Sega Saturn Emulation Module                                      */
 /******************************************************************************/
 /* vdp2.h:
-**  Copyright (C) 2015-2017 Mednafen Team
+**  Copyright (C) 2015-2019 Mednafen Team
 **
 ** This program is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU General Public License
@@ -92,6 +92,39 @@ enum
 
  GSREG_RAMCTL,
 
+ GSREG_BGON,
+ GSREG_MZCTL,
+ GSREG_SFSEL,
+ GSREG_SFCODE,
+ GSREG_CHCTLA,
+ GSREG_CHCTLB,
+
+ GSREG_SCXIN0,
+ GSREG_SCXDN0,
+ GSREG_SCYIN0,
+ GSREG_SCYDN0,
+ GSREG_ZMXIN0,
+ GSREG_ZMXDN0,
+ GSREG_ZMYIN0,
+ GSREG_ZMYDN0,
+
+ GSREG_SCXIN1,
+ GSREG_SCXDN1,
+ GSREG_SCYIN1,
+ GSREG_SCYDN1,
+ GSREG_ZMXIN1,
+ GSREG_ZMXDN1,
+ GSREG_ZMYIN1,
+ GSREG_ZMYDN1,
+
+ GSREG_SCXN2,
+ GSREG_SCYN2,
+ GSREG_SCXN3,
+ GSREG_SCYN3,
+
+ GSREG_ZMCTL,
+ GSREG_SCRCTL,
+
  GSREG_CYCA0,
  GSREG_CYCA1 = GSREG_CYCA0 + 1,
  GSREG_CYCB0 = GSREG_CYCA0 + 2,
@@ -101,8 +134,8 @@ enum
 
 uint32 GetRegister(const unsigned id, char* const special, const uint32 special_len);
 void SetRegister(const unsigned id, const uint32 value);
-uint8 PeekVRAM(const uint32 addr);
-void PokeVRAM(const uint32 addr, const uint8 val);
+uint8 PeekVRAM(uint32 addr);
+void PokeVRAM(uint32 addr, const uint8 val);
 #ifdef HAVE_DEBUG
 void MakeDump(const std::string& path) MDFN_COLD;
 #endif

--- a/mednafen/ss/vdp2.h
+++ b/mednafen/ss/vdp2.h
@@ -88,7 +88,15 @@ enum
  GSREG_BM,
  GSREG_IM,
  GSREG_VRES,
- GSREG_HRES
+ GSREG_HRES,
+
+ GSREG_RAMCTL,
+
+ GSREG_CYCA0,
+ GSREG_CYCA1 = GSREG_CYCA0 + 1,
+ GSREG_CYCB0 = GSREG_CYCA0 + 2,
+ GSREG_CYCB1 = GSREG_CYCA0 + 3
+
 };
 
 uint32 GetRegister(const unsigned id, char* const special, const uint32 special_len);

--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -2682,8 +2682,10 @@ static NO_INLINE void DrawLine(const uint16 out_line, const uint16 vdp2_line, co
    if(InterlaceMode == IM_DOUBLE && field)
    {
     const uint8 sc = (SCRCTL >> (n << 3));
+    const uint8 lss = ((sc >> 4) & 0x3);
 
-    CurLSA[n] += ((bool)(sc & 0x2) + (bool)(sc & 0x4) + (bool)(sc & 0x8)) << 1;
+    if(!lss)
+     CurLSA[n] += ((bool)(sc & 0x2) + (bool)(sc & 0x4) + (bool)(sc & 0x8)) << 1;
    }
    //
    //
@@ -2730,7 +2732,7 @@ static NO_INLINE void DrawLine(const uint16 out_line, const uint16 vdp2_line, co
   //
   // Line scroll
   //
-  unsigned ls_comp_line = vdp2_line;
+  const unsigned ls_comp_line = vdp2_line << (InterlaceMode == IM_DOUBLE);
 
   for(unsigned n = 0; n < 2; n++)
   {
@@ -2770,7 +2772,7 @@ static NO_INLINE void DrawLine(const uint16 out_line, const uint16 vdp2_line, co
      CurLSA[n]++;
     }
 
-    if(InterlaceMode == IM_DOUBLE)
+    if(InterlaceMode == IM_DOUBLE && !lss)
      CurLSA[n] += ((bool)(sc & 0x2) + (bool)(sc & 0x4) + (bool)(sc & 0x8)) << 1;
    }
 

--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -1706,6 +1706,7 @@ static void T_DrawNBG23(const unsigned n, uint64* bgbuf, const unsigned w, const
  // printf("(TA_bpp == %d && n == %d && VRAM_Mode == 0x%01x && (HRes & 0x6) == 0x%01x && MDFN_de64lsb(VCPRegs[0]) == 0x%016llxULL && MDFN_de64lsb(VCPRegs[1]) == 0x%016llxULL && MDFN_de64lsb(VCPRegs[2]) == 0x%016llxULL && MDFN_de64lsb(VCPRegs[3]) == 0x%016llxULL) || \n", TA_bpp, n, VRAM_Mode, HRes & 0x6, (unsigned long long)MDFN_de64lsb(VCPRegs[0]), (unsigned long long)MDFN_de64lsb(VCPRegs[1]), (unsigned long long)MDFN_de64lsb(VCPRegs[2]), (unsigned long long)MDFN_de64lsb(VCPRegs[3]));
  if(MDFN_UNLIKELY(
   /* Akumajou Dracula X */ (TA_bpp == 4 && n == 3 && VRAM_Mode == 0x2 && (HRes & 0x6) == 0x0 && MDFN_de64lsb(VCPRegs[0]) == 0x0f0f070406060505ULL && MDFN_de64lsb(VCPRegs[1]) == 0x0f0f0f0f0f0f0f0fULL && MDFN_de64lsb(VCPRegs[2]) == 0x0f0f03000f0f0201ULL && MDFN_de64lsb(VCPRegs[3]) == 0x0f0f0f0f0f0f0f0fULL) ||
+  /* Alien Trilogy      */ (TA_bpp == 4 && n == 3 && VRAM_Mode == 0x2 && (HRes & 0x6) == 0x0 && MDFN_de64lsb(VCPRegs[0]) == 0x07050f0f0f0f0606ULL && MDFN_de64lsb(VCPRegs[1]) == 0x0f0f0f0f0f0f0f0fULL && MDFN_de64lsb(VCPRegs[2]) == 0x0f0f0f0f0f0f0f0fULL && MDFN_de64lsb(VCPRegs[3]) == 0x0f0103020f0f0f0fULL) ||
   /* Daytona USA CCE    */ (TA_bpp == 4 && n == 2 && VRAM_Mode == 0x3 && (HRes & 0x6) == 0x0 && MDFN_de64lsb(VCPRegs[0]) == 0x0f0f0f0f00000404ULL && MDFN_de64lsb(VCPRegs[1]) == 0x0f0f0f060f0f0f0fULL && MDFN_de64lsb(VCPRegs[2]) == 0x0f0f0f0f0505070fULL && MDFN_de64lsb(VCPRegs[3]) == 0x0f0f03020f010f00ULL) ||
   0))
  {


### PR DESCRIPTION
Sync with mednafen 1.22.1 (latest version)

SS: Corrected line-scroll handling in double-density interlaced mode with non-zero LSS; fixes broken background graphics effect in Dural's stage in "Virtua Fighter 2".

SS: Added "Linkle Liver Story" to the internal database of games to use the data cache read bypass kludge with, to fix a crash/hang when going to the world map.

( Fixes #129 )