### PR TITLE
Sync with v1.22.2 of Mednafen

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -30,8 +30,8 @@ static INLINE bool DBG_NeedCPUHooks(void) { return false; } // <-- replaces debu
 #include <zlib.h>
 
 #define MEDNAFEN_CORE_NAME                   "Beetle Saturn"
-#define MEDNAFEN_CORE_VERSION                "v1.22.1"
-#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102201
+#define MEDNAFEN_CORE_VERSION                "v1.22.2"
+#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102202
 #define MEDNAFEN_CORE_EXTENSIONS             "cue|ccd|chd|toc|m3u"
 #define MEDNAFEN_CORE_TIMING_FPS             59.82
 #define MEDNAFEN_CORE_GEOMETRY_BASE_W        320

--- a/mednafen/ss/db.cpp
+++ b/mednafen/ss/db.cpp
@@ -159,6 +159,7 @@ static const struct
  { "T-1206G",	CPUCACHE_EMUMODE_DATA_CB },	// Street Fighter Zero (Japan)
  { "T-1246G",	CPUCACHE_EMUMODE_DATA_CB },	// Street Fighter Zero 3 (Japan)
  { "T-1215H",	CPUCACHE_EMUMODE_DATA_CB },	// Super Puzzle Fighter II Turbo (USA)
+ { "T-5001H",	CPUCACHE_EMUMODE_DATA_CB },	// Theme Park (Europe)
  { "GS-9113", CPUCACHE_EMUMODE_DATA_CB },	// Virtua Fighter Kids (Java Tea Original)
  { "T-15005G", CPUCACHE_EMUMODE_DATA_CB },	// Virtual Volleyball (Japan)
  { "T-18601H", CPUCACHE_EMUMODE_DATA_CB },	// WipEout (USA)


### PR DESCRIPTION
Only one Saturn related change in this version, but it fixes a crash bug.

`SS: Added the European release of "Theme Park" to the internal database of games to use the data cache read bypass kludge with, to fix a crash/hang during the intro FMV.`