### PR TITLE
Touchscreen lightgun support

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -1042,6 +1042,14 @@ void input_update( retro_input_state_t input_state_cb )
 						gun_y = ( ( gun_y_raw + 0x7fff ) * scale_y ) / (0x7fff << 1) + offset_y;
 					}
 
+					// position
+					p_input->gun_pos[ 0 ] = gun_x;
+					p_input->gun_pos[ 1 ] = gun_y;
+
+					// buttons
+					p_input->u8[ 4 ] = 0;
+
+					// trigger
 					if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER ) || forced_reload ) {
 						p_input->u8[ 4 ] |= shot_type;
 					}

--- a/input.cpp
+++ b/input.cpp
@@ -953,7 +953,6 @@ void input_update( retro_input_state_t input_state_cb )
 					gun_x_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X);
 					gun_y_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y);
 
-					printf("yoshi debug pointer raw: x = %i , y = %i \n", gun_x_raw, gun_y_raw);
 					// .. scale into screen space:
 					// NOTE: the scaling here is empirical-guesswork.
 					// Tested at 352x240 (ntsc) and 352x256 (pal)
@@ -970,7 +969,6 @@ void input_update( retro_input_state_t input_state_cb )
 					// Handle offscreen by checking corrected x and y values
 					if ( gun_x == 0 || gun_y == 0 )
 					{
-						printf("yoshi debug lightgun is offscreen! \n");
 						is_offscreen = 1;
 						gun_x = -16384; // magic position to disable cross-hair drawing.
 						gun_y = -16384;
@@ -994,7 +992,6 @@ void input_update( retro_input_state_t input_state_cb )
 					// 2-finger touch: Reload
 					// offscreen touch: Reload
 					int touch_count = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_COUNT );
-					printf("yoshi debug touch count = %i \n",touch_count);
 					if ( touch_count == 3 )
 					{
 						p_input->u8[ 4 ] |= 0x2;

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -246,6 +246,7 @@ extern "C" {
 #define RETRO_DEVICE_ID_POINTER_X         0
 #define RETRO_DEVICE_ID_POINTER_Y         1
 #define RETRO_DEVICE_ID_POINTER_PRESSED   2
+#define RETRO_DEVICE_ID_POINTER_COUNT     3
 
 /* Returned from retro_get_region(). */
 #define RETRO_REGION_NTSC  0

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1972,6 +1972,19 @@ static void check_variables(bool startup)
          setting_gun_crosshair = SETTING_GUN_CROSSHAIR_DOT;
       }
    }
+
+   var.key = "beetle_saturn_virtuagun_input";
+   var.value = NULL;
+
+   if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value )
+   {
+      if ( !strcmp(var.value, "Touchscreen") ) {
+         setting_gun_input = SETTING_GUN_INPUT_POINTER;
+      } else {
+         setting_gun_input = SETTING_GUN_INPUT_LIGHTGUN;
+      }
+   }
+
 }
 
 static bool MDFNI_LoadGame( const char *name )
@@ -2345,6 +2358,7 @@ void retro_set_environment( retro_environment_t cb )
       { "beetle_saturn_trigger_deadzone", "Trigger Deadzone; 15%|20%|25%|30%|0%|5%|10%"},
       { "beetle_saturn_mouse_sensitivity", "Mouse Sensitivity; 100%|105%|110%|115%|120%|125%|130%|135%|140%|145%|150%|155%|160%|165%|170%|175%|180%|185%|190%|195%|200%|5%|10%|15%|20%|25%|30%|35%|40%|45%|50%|55%|60%|65%|70%|75%|80%|85%|90%|95%" },
       { "beetle_saturn_virtuagun_crosshair", "Gun Crosshair; Cross|Dot|Off" },
+      { "beetle_saturn_virtuagun_input", "Gun Input Mode; Lightgun|Touchscreen" },
       { "beetle_saturn_cdimagecache", "CD Image Cache (restart); disabled|enabled" },
       { "beetle_saturn_midsync", "Mid-frame Input Synchronization; disabled|enabled" },
       { "beetle_saturn_autortc", "Automatically set RTC on game load; enabled|disabled" },

--- a/libretro_settings.cpp
+++ b/libretro_settings.cpp
@@ -9,6 +9,7 @@ int setting_initial_scanline_pal = 0;
 int setting_last_scanline = 239;
 int setting_last_scanline_pal = 287;
 int setting_gun_crosshair = SETTING_GUN_CROSSHAIR_CROSS;
+int setting_gun_input = SETTING_GUN_INPUT_LIGHTGUN;
 bool setting_disc_test = false;
 bool setting_multitap_port1;
 bool setting_multitap_port2;

--- a/libretro_settings.h
+++ b/libretro_settings.h
@@ -10,6 +10,12 @@ enum
 	SETTING_GUN_CROSSHAIR_LAST,
 };
 
+enum
+{
+	SETTING_GUN_INPUT_LIGHTGUN,
+	SETTING_GUN_INPUT_POINTER,
+};
+
 extern int setting_region;
 extern int setting_cart;
 extern bool setting_smpc_autortc;
@@ -19,6 +25,7 @@ extern int setting_initial_scanline_pal;
 extern int setting_last_scanline;
 extern int setting_last_scanline_pal;
 extern int setting_gun_crosshair;
+extern int setting_gun_input;
 extern bool setting_disc_test;
 extern bool setting_multitap_port1;
 extern bool setting_multitap_port2;


### PR DESCRIPTION
Support lightgun input using touchscreen. Added a core option to set the gun input mode (defaults to Lightgun).

For multi touch inputs to work, RetroArch needs to be updated to support `RETRO_DEVICE_ID_POINTER_COUNT` - the number of touches in the current input. This is the PR in the RetroArch repo:
https://github.com/libretro/RetroArch/pull/8959