### PR TITLE
Add disk control interface v1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.so
 *.dll
 *.pdb
 *.lib

--- a/disc.cpp
+++ b/disc.cpp
@@ -20,7 +20,13 @@ static bool g_eject_state;
 
 static int g_current_disc;
 
+static unsigned g_initial_disc;
+static std::string g_initial_disc_path;
+
 static std::vector<CDIF *> CDInterfaces;
+
+static std::vector<std::string> disk_image_paths;
+static std::vector<std::string> disk_image_labels;
 
 //
 // Remember to rebuild region database in db.cpp if changing the order of
@@ -152,11 +158,6 @@ static bool disk_get_eject_state(void)
 	return g_eject_state;
 }
 
-static unsigned disk_get_image_index(void)
-{
-	return g_current_disc;
-}
-
 static bool disk_set_image_index(unsigned index)
 {
 	// only listen if the tray is open
@@ -229,8 +230,12 @@ static bool disk_replace_image_index(unsigned index, const struct retro_game_inf
       if (index < CD_SelectedDisc)
          CD_SelectedDisc--;
 
+      disk_image_paths.erase(disk_image_paths.begin() + index);
+      disk_image_labels.erase(disk_image_labels.begin() + index);
+
       // Poke into psx.cpp
       CalcDiscSCEx();
+
       return true;
    }
 
@@ -248,6 +253,11 @@ static bool disk_replace_image_index(unsigned index, const struct retro_game_inf
    extract_basename(retro_cd_base_name, info->path, sizeof(retro_cd_base_name));
    /* Ugly, but needed to get proper disk swapping effect. */
    update_md5_checksum(iface);
+
+   /* Update disk path/label vectors */
+   disk_image_paths[index]  = info->path;
+   disk_image_labels[index] = retro_cd_base_name;
+
    return true;
 #endif
 }
@@ -257,13 +267,69 @@ static bool disk_add_image_index(void)
 	log_cb(RETRO_LOG_INFO, "disk_add_image_index called.\n");
 
 	CDInterfaces.push_back(NULL);
+	disk_image_paths.push_back("");
+	disk_image_labels.push_back("");
 	return true;
 }
 
+static bool disk_set_initial_image(unsigned index, const char *path)
+{
+	if (string_is_empty(path))
+		return false;
+
+	g_initial_disc      = index;
+	g_initial_disc_path = path;
+
+	return true;
+}
+
+static bool disk_get_image_path(unsigned index, char *path, size_t len)
+{
+	if (len < 1)
+		return false;
+
+	if ((index < CDInterfaces.size()) &&
+		 (index < disk_image_paths.size()))
+	{
+		if (!string_is_empty(disk_image_paths[index].c_str()))
+		{
+			strlcpy(path, disk_image_paths[index].c_str(), len);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static bool disk_get_image_label(unsigned index, char *label, size_t len)
+{
+	if (len < 1)
+		return false;
+
+	if ((index < CDInterfaces.size()) &&
+		 (index < disk_image_labels.size()))
+	{
+		if (!string_is_empty(disk_image_labels[index].c_str()))
+		{
+			strlcpy(label, disk_image_labels[index].c_str(), len);
+			return true;
+		}
+	}
+
+	return false;
+}
 
 //------------------------------------------------------------------------------
 // Global Functions
 //------------------------------------------------------------------------------
+
+/* This has to be 'global', since we need to
+ * access the current disk index inside
+ * libretro.cpp */
+unsigned disk_get_image_index(void)
+{
+	return g_current_disc;
+}
 
 static struct retro_disk_control_callback disk_interface =
 {
@@ -276,13 +342,69 @@ static struct retro_disk_control_callback disk_interface =
 	disk_add_image_index,
 };
 
+static struct retro_disk_control_ext_callback disk_interface_ext =
+{
+	disk_set_eject_state,
+	disk_get_eject_state,
+	disk_get_image_index,
+	disk_set_image_index,
+	disk_get_num_images,
+	disk_replace_image_index,
+	disk_add_image_index,
+	disk_set_initial_image,
+	disk_get_image_path,
+	disk_get_image_label,
+};
+
+void extract_basename(char *buf, const char *path, size_t size)
+{
+   const char *base = strrchr(path, '/');
+   if (!base)
+      base = strrchr(path, '\\');
+   if (!base)
+      base = path;
+
+   if (*base == '\\' || *base == '/')
+      base++;
+
+   strncpy(buf, base, size - 1);
+   buf[size - 1] = '\0';
+
+   char *ext = strrchr(buf, '.');
+   if (ext)
+      *ext = '\0';
+}
+
+void extract_directory(char *buf, const char *path, size_t size)
+{
+   strncpy(buf, path, size - 1);
+   buf[size - 1] = '\0';
+
+   char *base = strrchr(buf, '/');
+   if (!base)
+      base = strrchr(buf, '\\');
+
+   if (base)
+      *base = '\0';
+   else
+      buf[0] = '\0';
+}
+
 void disc_init( retro_environment_t environ_cb )
 {
+	unsigned dci_version = 0;
+
 	// start closed
 	g_eject_state = false;
 
+	g_initial_disc = 0;
+	g_initial_disc_path.clear();
+
 	// register vtable with environment
-	environ_cb( RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, &disk_interface );
+   if (environ_cb(RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION, &dci_version) && (dci_version >= 1))
+      environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE, &disk_interface_ext);
+   else
+      environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, &disk_interface);
 }
 
 void disc_calcgameid( uint8* id_out16, uint8* fd_id_out16, char* sgid )
@@ -353,6 +475,9 @@ void disc_cleanup()
 		delete CDInterfaces[i];
 	}
 	CDInterfaces.clear();
+
+	disk_image_paths.clear();
+	disk_image_labels.clear();
 
 	g_current_disc = 0;
 }
@@ -518,23 +643,48 @@ bool disc_load_content( MDFNGI* game_interface, const char* content_name, uint8*
 			if ( !strcasecmp( content_ext, ".m3u" ) )
 			{
 				// multiple discs
-				std::vector<std::string> file_list;
-				ReadM3U(file_list, content_name);
-				for(unsigned i = 0; i < file_list.size(); i++)
+				ReadM3U(disk_image_paths, content_name);
+				for(unsigned i = 0; i < disk_image_paths.size(); i++)
 				{
+					char image_label[4096];
 					bool success = true;
-					log_cb(RETRO_LOG_INFO, "Adding CD: \"%s\".\n", file_list[i].c_str());
-					CDIF *image  = CDIF_Open(file_list[i].c_str(), false);
+
+					image_label[0] = '\0';
+
+					log_cb(RETRO_LOG_INFO, "Adding CD: \"%s\".\n", disk_image_paths[i].c_str());
+					CDIF *image  = CDIF_Open(disk_image_paths[i].c_str(), false);
 					CDInterfaces.push_back(image);
+
+					extract_basename(
+							image_label, disk_image_paths[i].c_str(), sizeof(image_label));
+					disk_image_labels.push_back(image_label);
 				}
 			}
 			else
 			{
 				// single disc
+				char image_label[4096];
 				bool success = true;
+
+				image_label[0] = '\0';
+
+				disk_image_paths.push_back(content_name);
 				CDIF *image  = CDIF_Open(content_name, false);
 				CDInterfaces.push_back(image);
+
+				extract_basename(
+						image_label, content_name, sizeof(image_label));
+				disk_image_labels.push_back(image_label);
 			}
+
+			/* Attempt to set initial disk index */
+			if ((g_initial_disc > 0) &&
+				 (g_initial_disc < CDInterfaces.size()))
+				if (g_initial_disc < disk_image_paths.size())
+					if (string_is_equal(
+							disk_image_paths[g_initial_disc].c_str(),
+							g_initial_disc_path.c_str()))
+						g_current_disc = (int)g_initial_disc;
 		}
 	}
 	catch( std::exception &e )

--- a/disc.h
+++ b/disc.h
@@ -4,7 +4,12 @@
 #include "libretro.h"
 #include "mednafen/mednafen-types.h"
 
+extern void extract_basename(char *buf, const char *path, size_t size);
+extern void extract_directory(char *buf, const char *path, size_t size);
+
 // These routines handle disc drive front-end.
+
+extern unsigned disk_get_image_index(void);
 
 extern void disc_init( retro_environment_t environ_cb );
 

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1117,7 +1117,7 @@ enum retro_mod
                                             * This may be still be done regardless of the core options
                                             * interface version.
                                             *
-                                            * If version is 1 however, core options may instead be set by
+                                            * If version is >= 1 however, core options may instead be set by
                                             * passing an array of retro_core_option_definition structs to
                                             * RETRO_ENVIRONMENT_SET_CORE_OPTIONS, or a 2D array of
                                             * retro_core_option_definition structs to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
@@ -1132,8 +1132,8 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
-                                            * returns an API version of 1.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
@@ -1194,8 +1194,8 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
-                                            * returns an API version of 1.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
@@ -1244,6 +1244,47 @@ enum retro_mod
                                             *
                                             * Note that all core option variables will be set visible by
                                             * default when calling SET_VARIABLES/SET_CORE_OPTIONS.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER 56
+                                           /* unsigned * --
+                                            *
+                                            * Allows an implementation to ask frontend preferred hardware
+                                            * context to use. Core should use this information to deal
+                                            * with what specific context to request with SET_HW_RENDER.
+                                            *
+                                            * 'data' points to an unsigned variable
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION 57
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the disk control
+                                            * interface supported by the frontend. If callback return false,
+                                            * API version is assumed to be 0.
+                                            *
+                                            * In legacy code, the disk control interface is defined by passing
+                                            * a struct of type retro_disk_control_callback to
+                                            * RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE.
+                                            * This may be still be done regardless of the disk control
+                                            * interface version.
+                                            *
+                                            * If version is >= 1 however, the disk control interface may
+                                            * instead be defined by passing a struct of type
+                                            * retro_disk_control_ext_callback to
+                                            * RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE.
+                                            * This allows the core to provide additional information about
+                                            * disk images to the frontend and/or enables extra
+                                            * disk control functionality by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE 58
+                                           /* const struct retro_disk_control_ext_callback * --
+                                            * Sets an interface which frontend can use to eject and insert
+                                            * disk images, and also obtain information about individual
+                                            * disk image files registered by the core.
+                                            * This is used for games which consist of multiple images and
+                                            * must be manually swapped out by the user (e.g. PSX, floppy disk
+                                            * based systems).
                                             */
 
 /* VFS functionality */
@@ -1922,6 +1963,10 @@ enum retro_sensor_action
 {
    RETRO_SENSOR_ACCELEROMETER_ENABLE = 0,
    RETRO_SENSOR_ACCELEROMETER_DISABLE,
+   RETRO_SENSOR_GYROSCOPE_ENABLE,
+   RETRO_SENSOR_GYROSCOPE_DISABLE,
+   RETRO_SENSOR_ILLUMINANCE_ENABLE,
+   RETRO_SENSOR_ILLUMINANCE_DISABLE,
 
    RETRO_SENSOR_DUMMY = INT_MAX
 };
@@ -1930,6 +1975,10 @@ enum retro_sensor_action
 #define RETRO_SENSOR_ACCELEROMETER_X 0
 #define RETRO_SENSOR_ACCELEROMETER_Y 1
 #define RETRO_SENSOR_ACCELEROMETER_Z 2
+#define RETRO_SENSOR_GYROSCOPE_X 3
+#define RETRO_SENSOR_GYROSCOPE_Y 4
+#define RETRO_SENSOR_GYROSCOPE_Z 5
+#define RETRO_SENSOR_ILLUMINANCE 6
 
 typedef bool (RETRO_CALLCONV *retro_set_sensor_state_t)(unsigned port,
       enum retro_sensor_action action, unsigned rate);
@@ -2287,7 +2336,8 @@ struct retro_keyboard_callback
    retro_keyboard_event_t callback;
 };
 
-/* Callbacks for RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE.
+/* Callbacks for RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE &
+ * RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE.
  * Should be set for implementations which can swap out multiple disk
  * images in runtime.
  *
@@ -2345,6 +2395,53 @@ typedef bool (RETRO_CALLCONV *retro_replace_image_index_t)(unsigned index,
  * with replace_image_index. */
 typedef bool (RETRO_CALLCONV *retro_add_image_index_t)(void);
 
+/* Sets initial image to insert in drive when calling
+ * core_load_game().
+ * Since we cannot pass the initial index when loading
+ * content (this would require a major API change), this
+ * is set by the frontend *before* calling the core's
+ * retro_load_game()/retro_load_game_special() implementation.
+ * A core should therefore cache the index/path values and handle
+ * them inside retro_load_game()/retro_load_game_special().
+ * - If 'index' is invalid (index >= get_num_images()), the
+ *   core should ignore the set value and instead use 0
+ * - 'path' is used purely for error checking - i.e. when
+ *   content is loaded, the core should verify that the
+ *   disk specified by 'index' has the specified file path.
+ *   This is to guard against auto selecting the wrong image
+ *   if (for example) the user should modify an existing M3U
+ *   playlist. We have to let the core handle this because
+ *   set_initial_image() must be called before loading content,
+ *   i.e. the frontend cannot access image paths in advance
+ *   and thus cannot perform the error check itself.
+ *   If set path and content path do not match, the core should
+ *   ignore the set 'index' value and instead use 0
+ * Returns 'false' if index or 'path' are invalid, or core
+ * does not support this functionality
+ */
+typedef bool (RETRO_CALLCONV *retro_set_initial_image_t)(unsigned index, const char *path);
+
+/* Fetches the path of the specified disk image file.
+ * Returns 'false' if index is invalid (index >= get_num_images())
+ * or path is otherwise unavailable.
+ */
+typedef bool (RETRO_CALLCONV *retro_get_image_path_t)(unsigned index, char *path, size_t len);
+
+/* Fetches a core-provided 'label' for the specified disk
+ * image file. In the simplest case this may be a file name
+ * (without extension), but for cores with more complex
+ * content requirements information may be provided to
+ * facilitate user disk swapping - for example, a core
+ * running floppy-disk-based content may uniquely label
+ * save disks, data disks, level disks, etc. with names
+ * corresponding to in-game disk change prompts (so the
+ * frontend can provide better user guidance than a 'dumb'
+ * disk index value).
+ * Returns 'false' if index is invalid (index >= get_num_images())
+ * or label is otherwise unavailable.
+ */
+typedef bool (RETRO_CALLCONV *retro_get_image_label_t)(unsigned index, char *label, size_t len);
+
 struct retro_disk_control_callback
 {
    retro_set_eject_state_t set_eject_state;
@@ -2356,6 +2453,27 @@ struct retro_disk_control_callback
 
    retro_replace_image_index_t replace_image_index;
    retro_add_image_index_t add_image_index;
+};
+
+struct retro_disk_control_ext_callback
+{
+   retro_set_eject_state_t set_eject_state;
+   retro_get_eject_state_t get_eject_state;
+
+   retro_get_image_index_t get_image_index;
+   retro_set_image_index_t set_image_index;
+   retro_get_num_images_t  get_num_images;
+
+   retro_replace_image_index_t replace_image_index;
+   retro_add_image_index_t add_image_index;
+
+   /* NOTE: Frontend will only attempt to record/restore
+    * last used disk index if both set_initial_image()
+    * and get_image_path() are implemented */
+   retro_set_initial_image_t set_initial_image; /* Optional - may be NULL */
+
+   retro_get_image_path_t get_image_path;       /* Optional - may be NULL */
+   retro_get_image_label_t get_image_label;     /* Optional - may be NULL */
 };
 
 enum retro_pixel_format
@@ -2501,7 +2619,21 @@ struct retro_core_option_display
    bool visible;
 };
 
-/* Maximum number of values permitted for a core option */
+/* Maximum number of values permitted for a core option
+ * > Note: We have to set a maximum value due the limitations
+ *   of the C language - i.e. it is not possible to create an
+ *   array of structs each containing a variable sized array,
+ *   so the retro_core_option_definition values array must
+ *   have a fixed size. The size limit of 128 is a balancing
+ *   act - it needs to be large enough to support all 'sane'
+ *   core options, but setting it too large may impact low memory
+ *   platforms. In practise, if a core option has more than
+ *   128 values then the implementation is likely flawed.
+ *   To quote the above API reference:
+ *      "The number of possible options should be very limited
+ *       i.e. it should be feasible to cycle through options
+ *       without a keyboard."
+ */
 #define RETRO_NUM_CORE_OPTION_VALUES_MAX 128
 
 struct retro_core_option_value

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1624,41 +1624,6 @@ MDFNGI EmulatedSS =
    2,     // Number of output sound channels
 };
 
-
-static void extract_basename(char *buf, const char *path, size_t size)
-{
-   const char *base = strrchr(path, '/');
-   if (!base)
-      base = strrchr(path, '\\');
-   if (!base)
-      base = path;
-
-   if (*base == '\\' || *base == '/')
-      base++;
-
-   strncpy(buf, base, size - 1);
-   buf[size - 1] = '\0';
-
-   char *ext = strrchr(buf, '.');
-   if (ext)
-      *ext = '\0';
-}
-
-static void extract_directory(char *buf, const char *path, size_t size)
-{
-   strncpy(buf, path, size - 1);
-   buf[size - 1] = '\0';
-
-   char *base = strrchr(buf, '/');
-   if (!base)
-      base = strrchr(buf, '\\');
-
-   if (base)
-      *base = '\0';
-   else
-      buf[0] = '\0';
-}
-
 //forward decls
 static bool overscan;
 static double last_sound_rate;
@@ -2149,7 +2114,7 @@ bool retro_load_game(const struct retro_game_info *info)
 
    boot = false;
 
-   disc_select(0);
+   disc_select(disk_get_image_index());
 
    frame_count = 0;
    internal_frame_count = 0;


### PR DESCRIPTION
This PR adds full support for libretro disk control interface v1. This includes the following enhancements:

- Disk names are now shown when swapping disks via the  `Current Disk Index` drop down list:

![Screenshot_2020-01-22_16-03-48](https://user-images.githubusercontent.com/38211560/72918507-b0fea800-3d3d-11ea-9fd0-8f6afd469b82.png)

- When loading content via M3U playlists, the last used disk index is now automatically saved/restored.