### PR TITLE
Fix build on every Unix system that is not Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,9 @@ ifneq (,$(findstring unix,$(platform)))
          GL_LIB := -lGL
       endif
    endif
-	HAVE_CDROM = 1
+   ifneq ($(findstring Linux,$(shell uname -s)),)
+      HAVE_CDROM = 1
+   endif
 
 # OS X
 else ifeq ($(platform), osx)


### PR DESCRIPTION
This breaks on non-Android Unix systems that are not Linux as cdrom.c is looking for a Linux header. 
This simple patch fixes building on *BSD, Solaris and Haiku.
I'll be submitting similar patches for other repos that re-use this code.