### PR TITLE
added option to enable shared memory card support

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1794,13 +1794,11 @@ static void check_variables(bool startup)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-    // static bool shared_memorycards = true;
       if (!strcmp(var.value, "shared"))
          shared_memorycards = true;
       else if (!strcmp(var.value, "per game"))
          shared_memorycards = false;
 
-     // input_multitap( 1, connected );
    }
    
    var.key = "beetle_saturn_midsync";

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2434,7 +2434,7 @@ const char *MDFN_MakeFName(MakeFName_Type type, int id1, const char *cd1)
          snprintf(fullpath, sizeof(fullpath), "%s%c%s.%s",
                retro_save_directory,
                retro_slash,
-               (!shared_memorycards) ? retro_cd_base_name : "beetle_saturn",
+               (!shared_memorycards) ? retro_cd_base_name : "mednafen_saturn_libretro_shared",
                cd1);
          break;
       case MDFNMKF_FIRMWARE:

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1693,8 +1693,8 @@ static bool old_cdimagecache = false;
 static bool boot = true;
 
 // shared memory cards support
-static bool shared_memorycards = false;
-static bool shared_memorycards_toggle = false;
+bool shared_memorycards = false;
+bool shared_memorycards_toggle = true;
 
 static void check_variables(bool startup)
 {
@@ -1761,6 +1761,7 @@ static void check_variables(bool startup)
       input_multitap( 1, connected );
    }
 
+
    var.key = "beetle_saturn_multitap_port2";
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -1789,6 +1790,19 @@ static void check_variables(bool startup)
       }
    }
 
+   var.key = "beetle_saturn_sharedmem";
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+    // static bool shared_memorycards = true;
+      if (!strcmp(var.value, "shared"))
+         shared_memorycards = true;
+      else if (!strcmp(var.value, "per game"))
+         shared_memorycards = false;
+
+     // input_multitap( 1, connected );
+   }
+   
    var.key = "beetle_saturn_midsync";
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -2422,7 +2436,7 @@ const char *MDFN_MakeFName(MakeFName_Type type, int id1, const char *cd1)
          snprintf(fullpath, sizeof(fullpath), "%s%c%s.%s",
                retro_save_directory,
                retro_slash,
-               (!shared_memorycards) ? retro_cd_base_name : "mednafen_saturn_libretro_shared",
+               (!shared_memorycards) ? retro_cd_base_name : "beetle_saturn",
                cd1);
          break;
       case MDFNMKF_FIRMWARE:

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -198,6 +198,19 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled"
    },
+   
+   {
+      "beetle_saturn_sharedmem",
+      "Shared memory card",
+      "Enable shared memory card.",
+      {
+         { "shared", NULL },
+         { "per game", NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   
    {
       "beetle_saturn_midsync",
       "Mid-frame Input Synchronization",
@@ -512,6 +525,7 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled"
    },
+
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -201,14 +201,14 @@ struct retro_core_option_definition option_defs_us[] = {
    
    {
       "beetle_saturn_sharedmem",
-      "Shared memory card",
-      "Enable shared memory card.",
+      "Save file mode",
+      "Switches between shared or per game savefiles.",
       {
          { "shared", NULL },
          { "per game", NULL },
          { NULL, NULL },
       },
-      "disabled"
+      "shared"
    },
    
    {


### PR DESCRIPTION
Hi,
I added an option to use shared bcr and bkr, useful with multi disc games and games that need to share the saves (like duke nukem 3d and quake)