### PR TITLE
Add files via upload

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1794,10 +1794,10 @@ static void check_variables(bool startup)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "shared"))
-         shared_memorycards = true;
-      else if (!strcmp(var.value, "per game"))
-         shared_memorycards = false;
+      if (!strcmp(var.value, "enabled"))
+         shared_memorycards_toggle = true;
+      else if (!strcmp(var.value, "disabled"))
+         shared_memorycards_toggle = false;
 
    }
    

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -201,14 +201,14 @@ struct retro_core_option_definition option_defs_us[] = {
    
    {
       "beetle_saturn_sharedmem",
-      "Save file mode",
-      "Switches between shared or per game savefiles.",
+      "Shared Save Files (Restart)",
+      "Enables shared save files.",
       {
-         { "shared", NULL },
-         { "per game", NULL },
+         { "enabled", NULL },
+         { "disabled", NULL },
          { NULL, NULL },
       },
-      "shared"
+      "disabled"
    },
    
    {


### PR DESCRIPTION
Fixed the problem of "shared memory cards" option not working properly.
Now the change takes effect after restart.
Default setting set to "disabled"