### PR TITLE
Backport VDP2 render thread 'busy wait' performance fix

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -233,7 +233,8 @@ SOURCES_C += $(LIBRETRO_DIR)/streams/file_stream.c \
 				 $(LIBRETRO_DIR)/time/rtime.c
 
 ifeq ($(NEED_THREADING), 1)
-SOURCES_C += $(LIBRETRO_DIR)/rthreads/rthreads.c
+SOURCES_C += $(LIBRETRO_DIR)/rthreads/rthreads.c \
+				 $(LIBRETRO_DIR)/rthreads/rsemaphore.c
 endif
 
 endif


### PR DESCRIPTION
At present, the core uses 100% of one CPU core even when the runloop is paused. This is because the VDP2 rendering happens on a secondary thread which spends almost all of its time spinning in a busy wait loop.

This PR (trivially) backports the updated VDP2 thread handling method from upstream. Now the thread will only wake up to process events for the current frame - in between frames (and when the runloop is suspended by the frontend), it will be correctly 'paused'. This significantly reduces CPU usage.

Closes #188