### PR TITLE
Fix hang on boot when rewind or runahead is enabled

### DIFF
--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -3466,7 +3466,10 @@ void VDP2REND_Write16_DB(uint32 A, uint16 DB)
 void VDP2REND_StateAction(StateMem* sm, const unsigned load, const bool data_only, uint16 (&rr)[0x100], uint16 (&cr)[2048], uint16 (&vr)[262144])
 {
  while(MDFN_UNLIKELY(WQ_InCount.load(std::memory_order_acquire) != 0))
+ {
+  ssem_signal(WakeupSem);
   retro_sleep(1);
+ }
  //
  //
  //


### PR DESCRIPTION
#191 introduced an unfortunate regression - when starting content with fast forward or runahead enabled, the core will hang due to a deadlock between a wait in the VDP2 rendering thread and a wait in the VDP2 savestate function on the main thread. It seems that this is actually an upstream bug - but it never manifests there, since it is virtually impossible to trigger a savestate on the first frame when using standalone (whereas libretro rewind and runahead features cause this to happen immediately).

This PR fixes the problem by ensuring that the VDP2 savestate function 'wakes up' the VDP2 rendering thread when necessary.

