### PR TITLE
Prevent hang when launching Blast Wind

### DIFF
--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -3363,14 +3363,10 @@ void VDP2REND_StartFrame(EmulateSpecStruct* espec_arg, const bool clock28m, cons
 void VDP2REND_EndFrame(void)
 {
  while(MDFN_UNLIKELY(DrawCounter.load(std::memory_order_acquire) != 0))
-#if 0
  {
-  //fprintf(stderr, "SLEEEEP\n");
-  //retro_sleep(1);
+   ssem_signal(WakeupSem);
+   retro_sleep(1);
  }
-#else
- ;
-#endif
 
  WWQ(COMMAND_SET_BUSYWAIT, false);
 


### PR DESCRIPTION
As reported in this thread: https://github.com/libretro/beetle-saturn-libretro/pull/191#issuecomment-847413692, the core currently hangs when attempting to get past the title screen of the game 'Blast Wind'. This is caused by a similar thread deadlock issue to the one addressed here:  #197

This PR fixes the problem.