### PR TITLE
Add hack to fix hang at end of disc 1 of Grandia

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1011,7 +1011,9 @@ typedef struct
    const char *name;
 } CartName;
 
-static bool InitCommon(const unsigned cpucache_emumode, const unsigned cart_type, const unsigned smpc_area)
+uint32 ss_horrible_hacks;
+
+static bool InitCommon(const unsigned cpucache_emumode, const unsigned cart_type, const unsigned smpc_area, const uint32 horrible_hacks )
 {
 #ifdef MDFN_SS_DEV_BUILD
  ss_dbg_mask = SS_DBG_ERROR;
@@ -1088,6 +1090,8 @@ static bool InitCommon(const unsigned cpucache_emumode, const unsigned cart_type
       CPU[i].Init(cpucache_emumode == CPUCACHE_EMUMODE_DATA_CB);
       CPU[i].SetMD5((bool)i);
    }
+
+   ss_horrible_hacks = horrible_hacks;
 
    //
    // Initialize backup memory.
@@ -1942,6 +1946,7 @@ static bool MDFNI_LoadGame( const char *name )
    unsigned cpucache_emumode;
    int cart_type;
    unsigned region;
+   uint32 horrible_hacks = 0;
 
    // .. safe defaults
    region = SMPC_AREA_NA;
@@ -1984,7 +1989,7 @@ static bool MDFNI_LoadGame( const char *name )
             {
                disc_detect_region( &region );
 
-               DB_Lookup(nullptr, sgid, fd_id, &region, &cart_type, &cpucache_emumode );
+               DB_Lookup(nullptr, sgid, fd_id, &region, &cart_type, &cpucache_emumode, &horrible_hacks );
 
                // forced region setting?
                if ( setting_region != 0 ) {
@@ -1997,7 +2002,7 @@ static bool MDFNI_LoadGame( const char *name )
                }
 
                // GO!
-               if ( InitCommon( cpucache_emumode, cart_type, region ) )
+               if ( InitCommon( cpucache_emumode, cart_type, region, horrible_hacks ) )
                {
                   MDFN_LoadGameCheats(NULL);
                   MDFNMP_InstallReadPatches();
@@ -2039,7 +2044,7 @@ static bool MDFNI_LoadGame( const char *name )
    }
 
    // Initialise with safe parameters
-   InitCommon( cpucache_emumode, cart_type, region );
+   InitCommon( cpucache_emumode, cart_type, region, horrible_hacks );
 
    MDFN_LoadGameCheats(NULL);
    MDFNMP_InstallReadPatches();

--- a/mednafen/ss/db.cpp
+++ b/mednafen/ss/db.cpp
@@ -174,8 +174,21 @@ static const struct
  { "T-9515H-50", CPUCACHE_EMUMODE_FULL },	// Whizz (Europe)
 };
 
+static const struct
+{
+ const char* sgid;
+ unsigned horrible_hacks;
+ const char* game_name;
+ const char* purpose;
+ uint8 fd_id[16];
+} hhdb[] =
+{
+ { "T-4507G", HORRIBLEHACK_VDP1VRAM5000FIX } // "Grandia (Japan)", gettext_noop("Fixes hang at end of first disc.") },
+};
 
-void DB_Lookup(const char* path, const char* sgid, const uint8* fd_id, unsigned* const region, int* const cart_type, unsigned* const cpucache_emumode)
+void DB_Lookup(const char* path, const char* sgid, const uint8* fd_id,
+ unsigned* const region, int* const cart_type, unsigned* const cpucache_emumode,
+ unsigned* const hhv)
 {
  for(auto& re : regiondb)
  {
@@ -200,6 +213,15 @@ void DB_Lookup(const char* path, const char* sgid, const uint8* fd_id, unsigned*
   if((c.sgid && !strcmp(c.sgid, sgid)) || (!c.sgid && !memcmp(c.fd_id, fd_id, 16)))
   {
    *cpucache_emumode = c.mode;
+   break;
+  }
+ }
+
+ for(auto& hh : hhdb)
+ {
+  if(hh.sgid && !strcmp(hh.sgid, sgid))
+  {
+   *hhv = hh.horrible_hacks;
    break;
   }
  }

--- a/mednafen/ss/db.h
+++ b/mednafen/ss/db.h
@@ -29,7 +29,7 @@ enum
  CPUCACHE_EMUMODE_FULL
 };
 
-void DB_Lookup(const char* path, const char* sgid, const uint8* fd_id, unsigned* const region, int* const cart_type, unsigned* const cpucache_emumode);
+void DB_Lookup(const char* path, const char* sgid, const uint8* fd_id, unsigned* const region, int* const cart_type, unsigned* const cpucache_emumode, unsigned* const hhv);
 
 #endif
 

--- a/mednafen/ss/ss.h
+++ b/mednafen/ss/ss.h
@@ -27,6 +27,18 @@
 #include <stdint.h>
 #include <stdarg.h>
 
+#if 1
+ enum
+ {
+  HORRIBLEHACK_NOSH2DMALINE106	 = (1U << 0),
+  HORRIBLEHACK_NOSH2DMAPENALTY   = (1U << 1),
+  HORRIBLEHACK_VDP1VRAM5000FIX	 = (1U << 2),
+  HORRIBLEHACK_VDP1RWDRAWSLOWDOWN= (1U << 3),
+  HORRIBLEHACK_VDP1INSTANT	     = (1U << 4),
+ };
+ extern uint32 ss_horrible_hacks;
+#endif
+
  enum
  {
   SS_DBG_ERROR     = (1U << 0),

--- a/mednafen/ss/vdp1.cpp
+++ b/mednafen/ss/vdp1.cpp
@@ -575,6 +575,11 @@ void SetHBVB(const sscpu_timestamp_t event_timestamp, const bool new_hb_status, 
    //
    if(!(FBCR & FBCR_FCM) || (FBManualPending && (FBCR & FBCR_FCT)))	// Swap framebuffers
    {
+#if 1
+    if((ss_horrible_hacks & HORRIBLEHACK_VDP1VRAM5000FIX) && DrawingActive && VRAM[0] == 0x5000 && VRAM[1] == 0x0000)
+     VRAM[0] = 0x8000;
+#endif
+
     if(DrawingActive)
     {
 #ifdef HAVE_DEBUG


### PR DESCRIPTION
Hello,

Can you please add this hack that fixes the hang of the JRPG Grandia at the end of CD1?

Here's the original issue with a savestate and a screenshot of it being fixed:
[github.com/libretro/beetle-saturn-libretro/issues/201](https://github.com/libretro/beetle-saturn-libretro/issues/201)

Thanks!