### PR TITLE
Add a core option to enable/disable opposite directions

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -585,7 +585,13 @@ void input_update(bool supports_bitmasks,
 				p_input->buttons |=
 					input_state_cb( iplayer, RETRO_DEVICE_JOYPAD, 0, input_map_pad_left_shoulder ) ? ( 1 << 15 ) : 0;
 			}
-			break;
+
+         if (opposite_directions == false)
+         {
+           if ((p_input->buttons & 0x30) == 0x30) p_input->buttons &= ~0x30;
+           if ((p_input->buttons & 0xC0) == 0xC0) p_input->buttons &= ~0xC0;
+         }
+         break;
 
 		case RETRO_DEVICE_SS_TWINSTICK:
 

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1811,9 +1811,15 @@ static void check_variables(bool startup)
       input_multitap( 2, connected );
    }
 
+   var.key = "beetle_saturn_opposite_directions";
 
-
-
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "enabled"))
+         opposite_directions = true;
+      else if (!strcmp(var.value, "disabled"))
+         opposite_directions = false;
+   }
    
    var.key = "beetle_saturn_midsync";
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -394,6 +394,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "beetle_saturn_opposite_directions",
+      "Allow Up+Down and Left+Right",
+      NULL,
+      "Enabling this will allow pressing up and down or left and right directions at the same time. This may cause glitches.",
+      NULL,
+      "input",
+      {
+         { "disabled", NULL },
+         { "enabled", NULL },
+         { NULL, NULL},
+      },
+      "disabled"
+   },
+   {
       "beetle_saturn_analog_stick_deadzone",
       "Analog Stick Deadzone",
       NULL,

--- a/libretro_settings.cpp
+++ b/libretro_settings.cpp
@@ -13,4 +13,5 @@ int setting_gun_input = SETTING_GUN_INPUT_LIGHTGUN;
 bool setting_disc_test = false;
 bool setting_multitap_port1;
 bool setting_multitap_port2;
+bool opposite_directions;
 bool setting_midsync;

--- a/libretro_settings.h
+++ b/libretro_settings.h
@@ -29,6 +29,7 @@ extern int setting_gun_input;
 extern bool setting_disc_test;
 extern bool setting_multitap_port1;
 extern bool setting_multitap_port2;
+extern bool opposite_directions;
 extern bool setting_midsync;
 
 #endif


### PR DESCRIPTION
Added a core option to enable/disable Up+Down and Left+Right (disabled by default as it can cause glitches/unwanted behavior), tested on Earthworm Jim 2, PowerSlave and Magical Night Dreams: Cotton 2 (these games pause when pressing opposite directions) and it works fine.

I wouldn't mind a review (small PR, shouldn't take long!), I'm not a dev and it took me a while to understand how this stuff works (especially the bit operations...) but by looking at the Beetle PCE core, which has a similar option, I was able to figured it out. Like I said it worked in my tests but I could've missed something.

Fixes #204 