### PR TITLE
CHD: fix block address calculations

### DIFF
--- a/mednafen/cdrom/CDAccess_CHD.h
+++ b/mednafen/cdrom/CDAccess_CHD.h
@@ -24,6 +24,7 @@
 
 #include "CDAccess.h"
 #include <libchdr/chd.h>
+#include <libchdr/cdrom.h>
 
 struct CHDFILE_TRACK_INFO
 {
@@ -37,12 +38,13 @@ struct CHDFILE_TRACK_INFO
 
    int32_t postgap;
 
+   int32_t chd_offset;
+
    int32_t index[100];
 
    int32_t sectors; // Not including pregap sectors!
    bool FirstFileInstance;
    bool RawAudioMSBFirst;
-   long FileOffset;
    unsigned int SubchannelMode;
 
    uint32_t LastSamplePos;
@@ -70,17 +72,13 @@ class CDAccess_CHD : public CDAccess
   // MakeSubPQ will OR the simulated P and Q subchannel data into SubPWBuf.
   int32_t MakeSubPQ(int32_t lba, uint8_t *SubPWBuf) const;
 
-  bool Read_CHD_Hunk_RAW(uint8_t *buf, int32_t lba);
-  bool Read_CHD_Hunk_M1(uint8_t *buf, int32_t lba);
-  bool Read_CHD_Hunk_M2(uint8_t *buf, int32_t lba);
-
   int32_t NumTracks;
   int32_t FirstTrack;
   int32_t LastTrack;
   int32_t total_sectors;
   uint8_t disc_type;
   TOC toc;
-  CHDFILE_TRACK_INFO Tracks[100]; // Track #0(HMM?) through 99
+  CHDFILE_TRACK_INFO Tracks[CD_MAX_TRACKS + 1];
 
   //struct disc;
   //struct session sessions[DISC_MAX_SESSIONS];


### PR DESCRIPTION
CHDs tracks are padded to a 4-frame boundary, causing physical and CHD block addresses to differ after track 1. Adjusting sector reading to account for this offset fixes support of multi-data-track CHDs like Last Bronx (#162).

I've tested against ~30 CHDs successfully, but would be definitely good to further check compatibility against a wider sample.